### PR TITLE
Add a TeamPreMessageEvent and TeamMessageEvent to the API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.booksaw.betterTeams</groupId>
 	<artifactId>BetterTeams</artifactId>
-	<version>4.8.0</version>
+	<version>4.8.1</version>
 	<name>BetterTeams</name>
 	<packaging>jar</packaging>
 	<description>Create teams to fight to be the best</description>

--- a/src/main/java/com/booksaw/betterTeams/Team.java
+++ b/src/main/java/com/booksaw/betterTeams/Team.java
@@ -927,9 +927,11 @@ public class Team {
 		List<TeamPlayer> recipients = members.getClone();
 		recipients.removeIf(teamPlayer -> !teamPlayer.getPlayer().isOnline()); // Offline players won't be recipients
 		String format = MessageManager.getMessage("chat.syntax");
+		String prefix = sender.getPrefix(returnTo);
 
 		// Notify third party plugins that a team message is going to be sent
-		TeamPreMessageEvent teamPreMessageEvent = new TeamPreMessageEvent(this, sender, message, format, recipients);
+		TeamPreMessageEvent teamPreMessageEvent = new TeamPreMessageEvent(this, sender, message, format,
+				prefix, recipients);
 		Bukkit.getPluginManager().callEvent(teamPreMessageEvent);
 
 		// Process any updates after the event has been dispatched
@@ -938,13 +940,14 @@ public class Team {
 		} else {
 			message = teamPreMessageEvent.getRawMessage();
 			format = teamPreMessageEvent.getFormat();
+			prefix = teamPreMessageEvent.getSenderNamePrefix();
 		}
 
 		String fMessage = String.format(format,
-				sender.getPrefix(returnTo) + Objects.requireNonNull(sender.getPlayer().getPlayer()).getDisplayName(),
+				prefix + Objects.requireNonNull(sender.getPlayer().getPlayer()).getDisplayName(),
 				message);
 
-		fMessage = fMessage.replace("$name$", sender.getPrefix(returnTo) + sender.getPlayer().getPlayer().getName());
+		fMessage = fMessage.replace("$name$", prefix + sender.getPlayer().getPlayer().getName());
 		fMessage = fMessage.replace("$message$", message);
 
 		for (TeamPlayer player : teamPreMessageEvent.getRecipients()) {

--- a/src/main/java/com/booksaw/betterTeams/Team.java
+++ b/src/main/java/com/booksaw/betterTeams/Team.java
@@ -924,13 +924,15 @@ public class Team {
 		}
 
 		// These are variables which may be modified by TeamPreMessageEvent
-		List<TeamPlayer> teamMembers = members.getClone();
+		List<TeamPlayer> recipients = members.getClone();
+		recipients.removeIf(teamPlayer -> !teamPlayer.getPlayer().isOnline()); // Offline players won't be recipients
 		String format = MessageManager.getMessage("chat.syntax");
 
 		// Notify third party plugins that a team message is going to be sent
-		TeamPreMessageEvent teamPreMessageEvent = new TeamPreMessageEvent(this, sender, message, format, teamMembers);
+		TeamPreMessageEvent teamPreMessageEvent = new TeamPreMessageEvent(this, sender, message, format, recipients);
 		Bukkit.getPluginManager().callEvent(teamPreMessageEvent);
 
+		// Process any updates after the event has been dispatched
 		if (teamPreMessageEvent.isCancelled()) {
 			return;
 		} else {

--- a/src/main/java/com/booksaw/betterTeams/Team.java
+++ b/src/main/java/com/booksaw/betterTeams/Team.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import javax.annotation.Nullable;
 
+import com.booksaw.betterTeams.customEvents.TeamPreMessageEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
@@ -925,6 +926,18 @@ public class Team {
 			}
 		}
 
+		List<TeamPlayer> teamMembers = members.getClone();
+
+		// Notify third party plugins that a team message is going to be sent
+		TeamPreMessageEvent teamPreMessageEvent = new TeamPreMessageEvent(this, sender, message, teamMembers);
+		Bukkit.getPluginManager().callEvent(teamPreMessageEvent);
+
+		if (teamPreMessageEvent.isCancelled()) {
+			return;
+		} else {
+			message = teamPreMessageEvent.getRawMessage();
+		}
+
 		String fMessage = String.format(MessageManager.getMessage("chat.syntax"),
 				sender.getPrefix(returnTo) + Objects.requireNonNull(sender.getPlayer().getPlayer()).getDisplayName(),
 				message);
@@ -932,7 +945,7 @@ public class Team {
 		fMessage = fMessage.replace("$name$", sender.getPrefix(returnTo) + sender.getPlayer().getPlayer().getName());
 		fMessage = fMessage.replace("$message$", message);
 
-		for (TeamPlayer player : members.getClone()) {
+		for (TeamPlayer player : teamPreMessageEvent.getRecipients()) {
 			if (player.getPlayer().isOnline()) {
 				Objects.requireNonNull(player.getPlayer().getPlayer()).sendMessage(fMessage);
 			}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/TeamMessageEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/TeamMessageEvent.java
@@ -11,6 +11,9 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * An event which is called after a team message has been sent (notification only).
+ */
 public class TeamMessageEvent extends TeamPlayerEvent {
 
     private final String formattedMessage;

--- a/src/main/java/com/booksaw/betterTeams/customEvents/TeamMessageEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/TeamMessageEvent.java
@@ -1,0 +1,65 @@
+package com.booksaw.betterTeams.customEvents;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.google.common.collect.ImmutableSet;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Unmodifiable;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TeamMessageEvent extends TeamPlayerEvent {
+
+    private final String formattedMessage;
+    private final Set<TeamPlayer> recipients = new HashSet<>();
+
+    /**
+     * Creates an event with the original data for the message.
+     *
+     * @param team the team which the message is being sent to
+     * @param sender the sender of the message
+     * @param formattedMessage the message which has been sent (with the included formatting)
+     * @param recipients the current recipients of the message
+     */
+    public TeamMessageEvent(@NotNull Team team,
+                               @NotNull TeamPlayer sender,
+                               @NotNull String formattedMessage,
+                               @NotNull Collection<TeamPlayer> recipients) {
+        super(team, sender);
+        this.formattedMessage = formattedMessage;
+        this.recipients.addAll(recipients);
+    }
+
+    /**
+     * @return The contents of the message which has been sent (with formatting).
+     */
+    public String getFormattedMessage() {
+        return formattedMessage;
+    }
+
+    /**
+     * An immutable set of players which have received a copy of the message.
+     *
+     * @return An immutable (unmodifiable) set of players which have already received a copy of the message.
+     * @apiNote To change the recipients of a team message, use {@link TeamPreMessageEvent}.
+     */
+    public @Unmodifiable Set<TeamPlayer> getRecipients() {
+        return ImmutableSet.copyOf(recipients);
+    }
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/TeamMessageEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/TeamMessageEvent.java
@@ -53,6 +53,14 @@ public class TeamMessageEvent extends TeamPlayerEvent {
         return ImmutableSet.copyOf(recipients);
     }
 
+    /**
+     * @return The player who sent this message to their team.
+     * @apiNote A more readable overload of {@link #getTeamPlayer()}.
+     */
+    public TeamPlayer getSender() {
+        return getTeamPlayer();
+    }
+
     private static final HandlerList HANDLERS = new HandlerList();
 
     public static HandlerList getHandlerList() {

--- a/src/main/java/com/booksaw/betterTeams/customEvents/TeamPreMessageEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/TeamPreMessageEvent.java
@@ -2,6 +2,7 @@ package com.booksaw.betterTeams.customEvents;
 
 import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.TeamPlayer;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,6 +18,7 @@ public class TeamPreMessageEvent extends TeamPlayerEvent {
 
     private String rawMessage;
     private String format;
+    private String senderNamePrefix;
     private final Set<TeamPlayer> recipients = new HashSet<>();
 
     /**
@@ -26,16 +28,19 @@ public class TeamPreMessageEvent extends TeamPlayerEvent {
      * @param sender the sender of the message
      * @param rawMessage the contents of the message being sent (without formatting)
      * @param proposedFormat the proposed format for the message
+     * @param senderNamePrefix the prefix which will be appended to the sender's name in the formatted message
      * @param recipients the current recipients of the message
      */
     public TeamPreMessageEvent(@NotNull Team team,
                                @NotNull TeamPlayer sender,
                                @NotNull String rawMessage,
                                @NotNull String proposedFormat,
+                               @NotNull String senderNamePrefix,
                                @NotNull Collection<TeamPlayer> recipients) {
         super(team, sender);
         this.rawMessage = rawMessage;
         this.format = proposedFormat;
+        this.senderNamePrefix = senderNamePrefix;
         this.recipients.addAll(recipients);
     }
 
@@ -79,7 +84,31 @@ public class TeamPreMessageEvent extends TeamPlayerEvent {
      * @return The formatted message using the current format and raw message.
      */
     public String getFormattedMessage() {
-        return String.format(getFormat(), Objects.requireNonNull(getTeamPlayer().getPlayer().getPlayer()).getDisplayName(), getRawMessage());
+        return String.format(getFormat(), getFormattedSenderName(), getRawMessage());
+    }
+
+    /**
+     * @return The prefix that is put before the name of the sender in the message format.
+     */
+    public String getSenderNamePrefix() {
+        return senderNamePrefix;
+    }
+
+    /**
+     * Set the prefix to be attached to the sender's name in the message format.
+     *
+     * @param senderNamePrefix the new prefix
+     */
+    public void setSenderNamePrefix(@NotNull String senderNamePrefix) {
+        this.senderNamePrefix = Objects.requireNonNull(senderNamePrefix, "The prefix cannot be null");
+    }
+
+    /**
+     * @return The name of the sender as it will be displayed in the message format ('[prefix][name]').
+     * @apiNote The name of the sender is retrieved using {@link Player#getDisplayName()} and can be edited accordingly.
+     */
+    public String getFormattedSenderName() {
+        return getSenderNamePrefix() + Objects.requireNonNull(getSender().getPlayer().getPlayer()).getDisplayName();
     }
 
     /**

--- a/src/main/java/com/booksaw/betterTeams/customEvents/TeamPreMessageEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/TeamPreMessageEvent.java
@@ -16,6 +16,7 @@ import java.util.Set;
 public class TeamPreMessageEvent extends TeamPlayerEvent {
 
     private String rawMessage;
+    private String format;
     private final Set<TeamPlayer> recipients = new HashSet<>();
 
     /**
@@ -24,14 +25,17 @@ public class TeamPreMessageEvent extends TeamPlayerEvent {
      * @param team the team which the message is being sent to
      * @param sender the sender of the message
      * @param rawMessage the contents of the message being sent (without formatting)
+     * @param proposedFormat the proposed format for the message
      * @param recipients the current recipients of the message
      */
     public TeamPreMessageEvent(@NotNull Team team,
                                @NotNull TeamPlayer sender,
                                @NotNull String rawMessage,
+                               @NotNull String proposedFormat,
                                @NotNull Collection<TeamPlayer> recipients) {
         super(team, sender);
         this.rawMessage = rawMessage;
+        this.format = proposedFormat;
         this.recipients.addAll(recipients);
     }
 
@@ -49,6 +53,23 @@ public class TeamPreMessageEvent extends TeamPlayerEvent {
      */
     public void setRawMessage(@NotNull String rawMessage) {
         this.rawMessage = Objects.requireNonNull(rawMessage, "Team message cannot be null");
+    }
+
+    /**
+     * @return The format which will be used to format the message.
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * The format is as follows: '%s %s' -> '[player name] [message]'.
+     *
+     * @param newFormat the new format for the message following the format provided.
+     * @apiNote If you do not understand how this works, research {@link String#format(String, Object...)} for details.
+     */
+    public void setFormat(@NotNull String newFormat) {
+        this.format = Objects.requireNonNull(newFormat, "Team message format cannot be null");
     }
 
     /**

--- a/src/main/java/com/booksaw/betterTeams/customEvents/TeamPreMessageEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/TeamPreMessageEvent.java
@@ -1,0 +1,76 @@
+package com.booksaw.betterTeams.customEvents;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An event which is called before a message is sent from a {@link TeamPlayer} to members of their {@link Team}.
+ */
+public class TeamPreMessageEvent extends TeamPlayerEvent {
+
+    private String rawMessage;
+    private final Set<TeamPlayer> recipients = new HashSet<>();
+
+    /**
+     * Creates an event with the original data for the message.
+     *
+     * @param team the team which the message is being sent to
+     * @param sender the sender of the message
+     * @param rawMessage the contents of the message being sent (without formatting)
+     * @param recipients the current recipients of the message
+     */
+    public TeamPreMessageEvent(@NotNull Team team,
+                               @NotNull TeamPlayer sender,
+                               @NotNull String rawMessage,
+                               @NotNull Collection<TeamPlayer> recipients) {
+        super(team, sender);
+        this.rawMessage = rawMessage;
+        this.recipients.addAll(recipients);
+    }
+
+    /**
+     * @return The contents of the message which will be sent (without formatting).
+     */
+    public String getRawMessage() {
+        return rawMessage;
+    }
+
+    /**
+     * Sets the content for the message which will be sent (before formatting).
+     *
+     * @param rawMessage The new content of the message.
+     */
+    public void setRawMessage(@NotNull String rawMessage) {
+        this.rawMessage = Objects.requireNonNull(rawMessage, "Team message cannot be null");
+    }
+
+    /**
+     * A mutable set of players which are going to receive a copy of the message.
+     *
+     * @return A mutable (modifiable) set of players which are going to receive a copy of the message.
+     * @apiNote To change who will receive the message, edit this {@link Set}.
+     */
+    public Set<TeamPlayer> getRecipients() {
+        return recipients;
+    }
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/TeamPreMessageEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/TeamPreMessageEvent.java
@@ -65,11 +65,21 @@ public class TeamPreMessageEvent extends TeamPlayerEvent {
     /**
      * The format is as follows: '%s %s' -> '[player name] [message]'.
      *
-     * @param newFormat the new format for the message following the format provided.
+     * @param newFormat The new format for the message following the format provided.
      * @apiNote If you do not understand how this works, research {@link String#format(String, Object...)} for details.
      */
     public void setFormat(@NotNull String newFormat) {
         this.format = Objects.requireNonNull(newFormat, "Team message format cannot be null");
+    }
+
+    /**
+     * Using {@link #getFormat()} and {@link #getRawMessage()}, this method will format the raw message and return the
+     * formatted message using the current format.
+     *
+     * @return The formatted message using the current format and raw message.
+     */
+    public String getFormattedMessage() {
+        return String.format(getFormat(), Objects.requireNonNull(getTeamPlayer().getPlayer().getPlayer()).getDisplayName(), getRawMessage());
     }
 
     /**
@@ -80,6 +90,14 @@ public class TeamPreMessageEvent extends TeamPlayerEvent {
      */
     public Set<TeamPlayer> getRecipients() {
         return recipients;
+    }
+
+    /**
+     * @return The player sending this message to their team.
+     * @apiNote A more readable overload of {@link #getTeamPlayer()}.
+     */
+    public TeamPlayer getSender() {
+        return getTeamPlayer();
     }
 
     private static final HandlerList HANDLERS = new HandlerList();


### PR DESCRIPTION
I would like to propose the addition of a TeamPreMessageEvent and TeamMessageEvent to allow third-party developers to more accurately detect, amend and cancel team messages. 

This pull request contains the following amendments:

- Created a new class TeamPreMessageEvent which contains all the components of a team message and allows modifiable components to be modified before a team message is dispatched.
- Created a new class TeamMessageEvent which serves as a read-only notification that a message has been sent for monitoring purposes (such as third-party spy or audit plugins). 
- Implemented TeamPreMessageEvent in the existing Team class under method `Team#sendMessage(TeamPlayer, String)` by creating the event, providing it with the message components, dispatching the event, parsing all the returned values, and dispatching the team message with those (potentially) modified values.
- Implemented TeamMessageEvent as the final line in the `Team#sendMessage(...)` method which dispatches the notification event with the final message and components. 
- Changed to version 4.8.1 as a minor change.

The reason for this change comes from a recent plugin I created relating to a chat filter which was forced to use AsyncPlayerChatEvent and PlayerCommandPreprocessEvent to filter and cancel messages, which was not a perfect solution as you may imagine. These events will make the API a lot more future-proof by providing supported events for chat messages rather than having to find workarounds which could be rendered useless if a major plugin update happened. 

Happy to hear your thoughts on the new code!