### PR TITLE
Adds placeholders to get members at a specific rank

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
@@ -5,25 +5,7 @@ package com.booksaw.betterTeams.integrations.placeholder;
 
 import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.TeamPlayer;
-import com.booksaw.betterTeams.integrations.placeholder.provider.ColorPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.DescriptionPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.DisplayNamePlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.LevelPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.MaxMembersPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.MaxMoneyPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.MaxWarpsPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.MembersPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.MoneyPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.NamePlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.OfflineListPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.OnlineListPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.OnlinePlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.OpenPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.PvpPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.RankPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.ScorePlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.TagPlaceholderProvider;
-import com.booksaw.betterTeams.integrations.placeholder.provider.TitlePlaceholderProvider;
+import com.booksaw.betterTeams.integrations.placeholder.provider.*;
 
 /**
  * @author booksaw
@@ -35,7 +17,7 @@ public enum TeamPlaceholderOptionsEnum {
 	OPEN(new OpenPlaceholderProvider()), SCORE(new ScorePlaceholderProvider()), MONEY(new MoneyPlaceholderProvider()),
 	RANK(new RankPlaceholderProvider()), COLOR(new ColorPlaceholderProvider()), TITLE(new TitlePlaceholderProvider()),
 	ONLINELIST(new OnlineListPlaceholderProvider()), OFFLINELIST(new OfflineListPlaceholderProvider()),
-	ONLINE(new OnlinePlaceholderProvider()), MEMBERS(new MembersPlaceholderProvider()),
+	ONLINE(new OnlinePlaceholderProvider()), MEMBERS(new MembersPlaceholderProvider()), OWNERS(new OwnersPlaceholderProvider()),
 	LEVEL(new LevelPlaceholderProvider()), MAXMONEY(new MaxMoneyPlaceholderProvider()),
 	MAXMEMBERS(new MaxMembersPlaceholderProvider()), MAXWARPS(new MaxWarpsPlaceholderProvider()),
 	PVP(new PvpPlaceholderProvider());

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
@@ -17,7 +17,7 @@ public enum TeamPlaceholderOptionsEnum {
 	OPEN(new OpenPlaceholderProvider()), SCORE(new ScorePlaceholderProvider()), MONEY(new MoneyPlaceholderProvider()),
 	RANK(new RankPlaceholderProvider()), COLOR(new ColorPlaceholderProvider()), TITLE(new TitlePlaceholderProvider()),
 	ONLINELIST(new OnlineListPlaceholderProvider()), OFFLINELIST(new OfflineListPlaceholderProvider()),
-	ONLINE(new OnlinePlaceholderProvider()), MEMBERS(new MembersPlaceholderProvider()),
+	ONLINE(new OnlinePlaceholderProvider()), MEMBERS(new MembersPlaceholderProvider()), DEFAULTMEMBERS(new DefaultMembersPlaceholderProvider()),
 	ADMINS(new AdminsPlaceholderProvider()), OWNERS(new OwnersPlaceholderProvider()),
 	LEVEL(new LevelPlaceholderProvider()), MAXMONEY(new MaxMoneyPlaceholderProvider()),
 	MAXMEMBERS(new MaxMembersPlaceholderProvider()), MAXWARPS(new MaxWarpsPlaceholderProvider()),

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
@@ -17,7 +17,8 @@ public enum TeamPlaceholderOptionsEnum {
 	OPEN(new OpenPlaceholderProvider()), SCORE(new ScorePlaceholderProvider()), MONEY(new MoneyPlaceholderProvider()),
 	RANK(new RankPlaceholderProvider()), COLOR(new ColorPlaceholderProvider()), TITLE(new TitlePlaceholderProvider()),
 	ONLINELIST(new OnlineListPlaceholderProvider()), OFFLINELIST(new OfflineListPlaceholderProvider()),
-	ONLINE(new OnlinePlaceholderProvider()), MEMBERS(new MembersPlaceholderProvider()), OWNERS(new OwnersPlaceholderProvider()),
+	ONLINE(new OnlinePlaceholderProvider()), MEMBERS(new MembersPlaceholderProvider()),
+	ADMINS(new AdminsPlaceholderProvider()), OWNERS(new OwnersPlaceholderProvider()),
 	LEVEL(new LevelPlaceholderProvider()), MAXMONEY(new MaxMoneyPlaceholderProvider()),
 	MAXMEMBERS(new MaxMembersPlaceholderProvider()), MAXWARPS(new MaxWarpsPlaceholderProvider()),
 	PVP(new PvpPlaceholderProvider());

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/AdminsPlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/AdminsPlaceholderProvider.java
@@ -7,14 +7,14 @@ import com.booksaw.betterTeams.integrations.placeholder.IndividualTeamPlaceholde
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class OwnersPlaceholderProvider implements IndividualTeamPlaceholderProvider {
+public class AdminsPlaceholderProvider implements IndividualTeamPlaceholderProvider {
 
     @Override
     public String getPlaceholderForTeam(Team team) {
-        // Convert the List<TeamPlayer> to a List<String> of owner names
-        List<String> ownerNamesList = team.getRank(PlayerRank.OWNER).stream().map(teamPlayer -> teamPlayer.getPlayer().getName()).collect(Collectors.toList());
+        // Convert the List<TeamPlayer> to a List<String> of admin names
+        List<String> adminNamesList = team.getRank(PlayerRank.ADMIN).stream().map(teamPlayer -> teamPlayer.getPlayer().getName()).collect(Collectors.toList());
 
-        return String.join(", ", ownerNamesList);
+        return String.join(", ", adminNamesList);
 
     }
 

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/DefaultMembersPlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/DefaultMembersPlaceholderProvider.java
@@ -1,0 +1,20 @@
+package com.booksaw.betterTeams.integrations.placeholder.provider;
+
+import com.booksaw.betterTeams.PlayerRank;
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.integrations.placeholder.IndividualTeamPlaceholderProvider;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DefaultMembersPlaceholderProvider implements IndividualTeamPlaceholderProvider {
+
+    @Override
+    public String getPlaceholderForTeam(Team team) {
+        // Convert the List<TeamPlayer> to a List<String> of default member names
+        List<String> defaultMemberNamesList = team.getRank(PlayerRank.DEFAULT).stream().map(teamPlayer -> teamPlayer.getPlayer().getName()).collect(Collectors.toList());
+
+        return String.join(", ", defaultMemberNamesList);
+    }
+
+}

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/OwnersPlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/OwnersPlaceholderProvider.java
@@ -1,0 +1,26 @@
+package com.booksaw.betterTeams.integrations.placeholder.provider;
+
+import com.booksaw.betterTeams.PlayerRank;
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.integrations.placeholder.IndividualTeamPlaceholderProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OwnersPlaceholderProvider implements IndividualTeamPlaceholderProvider {
+
+    @Override
+    public String getPlaceholderForTeam(Team team) {
+        List<String> ownersList = new ArrayList<>();
+        for (TeamPlayer teamplayer : team.getMembers().get()) {
+            if (teamplayer.getRank().equals(PlayerRank.OWNER)) {
+                ownersList.add(teamplayer.getPlayer().getName());
+            }
+        }
+
+        return String.join(", ", ownersList);
+
+    }
+
+}


### PR DESCRIPTION
Adds placeholders to get the member(s) at a specific rank. If there are multiple with the same rank then they are all returned separated by commas. Closes #537
- `%betterteams_owners%` - Gets the owner(s) for the team that the viewing player is a member of
- `%betterteams_static_owners_Supers%` - Gets the owner(s) for the team "Supers"
- `%betterteams_admins%` - Gets the admin(s) for the team that the viewing player is a member of
- `%betterteams_static_admins_Supers%` - Gets the admin(s) for the team "Supers"
- `%betterteams_defaultmembers%` - Gets the default member(s) for the team that the viewing player is a member of
- `%betterteams_static_defaultmembers_Supers%` - Gets the default member(s) for the team "Supers"