### PR TITLE
Adds chat prefix to go from global to team or ally chat

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/events/ChatManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/ChatManagement.java
@@ -47,9 +47,13 @@ public class ChatManagement implements Listener {
 			throw new IllegalStateException("Player " + p.getName() + " is registered to be in a team, yet has no playerdata associated with that team");
 		}
 
+		String anyChatToGlobalPrefix = Main.plugin.getConfig().getString("chatPrefixes.teamOrAllyToGlobal", "!");
+		String globalToTeamPrefix = Main.plugin.getConfig().getString("chatPrefixes.globalToTeam", "!");
+		String globalToAllyPrefix = Main.plugin.getConfig().getString("chatPrefixes.globalToAlly", "?");
+
 		if (teamPlayer.isInTeamChat() || teamPlayer.isInAllyChat()) {
-			if (event.getMessage().startsWith("!") && event.getMessage().length() > 1) {
-				event.setMessage(event.getMessage().substring(1));
+			if (!anyChatToGlobalPrefix.isEmpty() && event.getMessage().startsWith(anyChatToGlobalPrefix) && event.getMessage().length() > anyChatToGlobalPrefix.length()) {
+				event.setMessage(event.getMessage().substring(anyChatToGlobalPrefix.length()));
 			} else {
 				// Player is not sending to global chat
 				event.setCancelled(true);
@@ -64,14 +68,17 @@ public class ChatManagement implements Listener {
 				event.setFormat("");
 				return;
 			}
-		} else if ((event.getMessage().startsWith("!") || event.getMessage().startsWith("?")) && event.getMessage().length() > 1) {
+		} else if (
+				(!globalToTeamPrefix.isEmpty() && event.getMessage().startsWith(globalToTeamPrefix) && event.getMessage().length() > globalToTeamPrefix.length())
+				|| (!globalToAllyPrefix.isEmpty() && event.getMessage().startsWith(globalToAllyPrefix) && event.getMessage().length() > globalToAllyPrefix.length())
+		) {
 			// Player is not sending to global chat
 			event.setCancelled(true);
 
-			if (event.getMessage().startsWith("!")) {
-				team.sendMessage(teamPlayer, event.getMessage().substring(1));
+			if (event.getMessage().startsWith(globalToTeamPrefix)) {
+				team.sendMessage(teamPlayer, event.getMessage().substring(globalToTeamPrefix.length()));
 			} else {
-				team.sendAllyMessage(teamPlayer, event.getMessage().substring(1));
+				team.sendAllyMessage(teamPlayer, event.getMessage().substring(globalToAllyPrefix.length()));
 			}
 			// Used as some chat plugins do not accept when a message is cancelled
 			event.setMessage("");

--- a/src/main/java/com/booksaw/betterTeams/events/ChatManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/ChatManagement.java
@@ -34,6 +34,10 @@ public class ChatManagement implements Listener {
 	@EventHandler(priority = EventPriority.HIGH)
 	public void onChat(AsyncPlayerChatEvent event) {
 
+		if (event.isCancelled()) {
+			return;
+		}
+
 		Player p = event.getPlayer();
 		Team team = Team.getTeam(p);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -86,6 +86,16 @@ announceTeamLeave: false
 # This is used to determine whether disbanding a team should be announced (Message is configurable in messages.yml)
 announceTeamDisband: false
 
+# These are prefix shortcuts to change where a chat message is sent
+# Possible values: [Any text/character(s)]
+chatPrefixes:
+   # This prefix will instead send the global message to the team chat
+   globalToTeam: '!'
+   # This prefix will instead send the global message to the ally chat
+   globalToAlly: '?'
+   # This prefix will instead send the team or ally message to the global chat
+   teamOrAllyToGlobal: '!'
+
 # This is used to set the maxmimum number of allies a team can have
 # - If this feature is unwanted, set the allyLimit to -1 and there will be unlimited allies for each team
 # - Keep this value reasonable, as Java cannot cope with larger numbers (over 2 billion), so if you want the team to be limitless, set the value to -1 instead of something large


### PR DESCRIPTION
Adds prefixes to go from the global chat to either the team or ally chat. These prefixes are all configurable and the prefix to go from the team chat or ally chat to the global chat has also been updated to be configurable. Resolves #314