### PR TITLE
Adds placeholders to get current positions

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
@@ -19,8 +19,9 @@ public enum TeamPlaceholderOptionsEnum {
 	ONLINELIST(new OnlineListPlaceholderProvider()), OFFLINELIST(new OfflineListPlaceholderProvider()),
 	ONLINE(new OnlinePlaceholderProvider()), MEMBERS(new MembersPlaceholderProvider()), DEFAULTMEMBERS(new DefaultMembersPlaceholderProvider()),
 	ADMINS(new AdminsPlaceholderProvider()), OWNERS(new OwnersPlaceholderProvider()),
-	LEVEL(new LevelPlaceholderProvider()), MAXMONEY(new MaxMoneyPlaceholderProvider()),
-	MAXMEMBERS(new MaxMembersPlaceholderProvider()), MAXWARPS(new MaxWarpsPlaceholderProvider()),
+	POSITIONSCORE(new PositionScorePlaceholderProvider()), POSITIONBAL(new PositionBalPlaceholderProvider()),
+	POSITIONMEMBERS(new PositionMembersPlaceholderProvider()), LEVEL(new LevelPlaceholderProvider()),
+	MAXMONEY(new MaxMoneyPlaceholderProvider()), MAXMEMBERS(new MaxMembersPlaceholderProvider()), MAXWARPS(new MaxWarpsPlaceholderProvider()),
 	PVP(new PvpPlaceholderProvider());
 
 	private final IndividualTeamPlaceholderProvider teamProvider;

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/PositionBalPlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/PositionBalPlaceholderProvider.java
@@ -1,0 +1,20 @@
+package com.booksaw.betterTeams.integrations.placeholder.provider;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.integrations.placeholder.IndividualTeamPlaceholderProvider;
+import org.apache.commons.lang.ArrayUtils;
+
+public class PositionBalPlaceholderProvider implements IndividualTeamPlaceholderProvider {
+
+    @Override
+    public String getPlaceholderForTeam(Team team) {
+
+        String[] teamsByBalance = Team.getTeamManager().sortTeamsByBalance();
+
+        int balPosition = ArrayUtils.indexOf(teamsByBalance, team.getName()) + 1;
+
+        return balPosition + "";
+
+    }
+
+}

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/PositionMembersPlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/PositionMembersPlaceholderProvider.java
@@ -1,0 +1,20 @@
+package com.booksaw.betterTeams.integrations.placeholder.provider;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.integrations.placeholder.IndividualTeamPlaceholderProvider;
+import org.apache.commons.lang.ArrayUtils;
+
+public class PositionMembersPlaceholderProvider implements IndividualTeamPlaceholderProvider {
+
+    @Override
+    public String getPlaceholderForTeam(Team team) {
+
+        String[] teamsByMembers = Team.getTeamManager().sortTeamsByMembers();
+
+        int membersPosition = ArrayUtils.indexOf(teamsByMembers, team.getName()) + 1;
+
+        return membersPosition + "";
+
+    }
+
+}

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/PositionScorePlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/PositionScorePlaceholderProvider.java
@@ -1,0 +1,20 @@
+package com.booksaw.betterTeams.integrations.placeholder.provider;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.integrations.placeholder.IndividualTeamPlaceholderProvider;
+import org.apache.commons.lang.ArrayUtils;
+
+public class PositionScorePlaceholderProvider implements IndividualTeamPlaceholderProvider {
+
+    @Override
+    public String getPlaceholderForTeam(Team team) {
+
+        String[] teamsByScore = Team.getTeamManager().sortTeamsByScore();
+
+        int scorePosition = ArrayUtils.indexOf(teamsByScore, team.getName()) + 1;
+
+        return scorePosition + "";
+
+    }
+
+}


### PR DESCRIPTION
Adds placeholders to get the numerical position in the three existing ranked lists. Currently does not handle number formatting i.e. 5120109 would be returned with no commas or periods denoting 1000s. Closes #538
- `positionscore` - Current position of the team ranked by score
- `positionbal` - Current position of the team ranked by balance
- `positionmembers` - Current position of the team ranked by amount of members