### PR TITLE
Expose player in certain events and cleanup

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -131,9 +131,15 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.sk89q.worldedit</groupId>
+      <artifactId>worldedit-bukkit</artifactId>
+      <version>7.2.8</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.sk89q.worldguard</groupId>
       <artifactId>worldguard-bukkit</artifactId>
-      <version>7.0.4</version>
+      <version>7.0.5</version>
       <scope>provided</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-bukkit</artifactId>
+            <version>7.2.8</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.4</version>
+            <version>7.0.5</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/com/booksaw/betterTeams/Main.java
+++ b/src/main/java/com/booksaw/betterTeams/Main.java
@@ -20,7 +20,7 @@ import com.booksaw.betterTeams.cost.CostManager;
 import com.booksaw.betterTeams.events.*;
 import com.booksaw.betterTeams.events.MCTeamManagement.BelowNameType;
 import com.booksaw.betterTeams.integrations.UltimateClaimsManager;
-import com.booksaw.betterTeams.integrations.WorldGaurdManagerV7;
+import com.booksaw.betterTeams.integrations.WorldGuardManagerV7;
 import com.booksaw.betterTeams.integrations.ZKothManager;
 import com.booksaw.betterTeams.integrations.hologram.DHHologramManager;
 import com.booksaw.betterTeams.integrations.hologram.HDHologramManager;
@@ -60,7 +60,7 @@ public class Main extends JavaPlugin {
 	public boolean useHolograms = false;
 	public MCTeamManagement teamManagement;
 	public ChatManagement chatManagement;
-	public WorldGaurdManagerV7 wgManagement;
+	public WorldGuardManagerV7 wgManagement;
 	private PermissionParentCommand teamCommand;
 
 	private BooksawCommand teamBooksawCommand;
@@ -84,7 +84,7 @@ public class Main extends JavaPlugin {
 				&& configManager.config.getBoolean("worldGuard.enabled")) {
 			char ver = Bukkit.getPluginManager().getPlugin("WorldGuard").getDescription().getVersion().charAt(0);
 			if (ver == '7') {
-				wgManagement = new WorldGaurdManagerV7();
+				wgManagement = new WorldGuardManagerV7();
 			} else {
 				Bukkit.getLogger().warning("[BetterTeams] Your version of worldgaurd ("
 						+ Bukkit.getPluginManager().getPlugin("WorldGuard").getDescription().getVersion()

--- a/src/main/java/com/booksaw/betterTeams/Team.java
+++ b/src/main/java/com/booksaw/betterTeams/Team.java
@@ -18,8 +18,8 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scoreboard.Scoreboard;
+import org.jetbrains.annotations.Nullable;
 
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -629,8 +629,6 @@ public class Team {
 
 	/**
 	 * Used to save the members list to the configuration file
-	 *
-	 * @param config the configuration file to store the members list to
 	 */
 	private void savePlayers() {
 		members.save(getStorage());
@@ -638,8 +636,6 @@ public class Team {
 
 	/**
 	 * Used to save the bans list to the configuration file
-	 *
-	 * @param config the configuration file to store the ban list to
 	 */
 	private void saveBans() {
 		bannedPlayers.save(getStorage());
@@ -710,7 +706,16 @@ public class Team {
 	 * This command is used to disband a team, BE CAREFUL, this is irreversible
 	 */
 	public void disband() {
-		DisbandTeamEvent event = new DisbandTeamEvent(this);
+		disband(null);
+	}
+
+	/**
+	 * This command is used to disband a team, BE CAREFUL, this is irreversible
+	 *
+	 * @param player The player responsible for disbandment [null - initiated by console]
+	 */
+	public void disband(Player player) {
+		DisbandTeamEvent event = new DisbandTeamEvent(this, player);
 		Bukkit.getPluginManager().callEvent(event);
 
 		if (event.isCancelled()) {
@@ -733,8 +738,8 @@ public class Team {
 //			}
 //		}
 
-		for (TeamPlayer player : getMembers().get()) {
-			getTeamManager().playerLeaveTeam(this, player);
+		for (TeamPlayer teamPlayer : getMembers().get()) {
+			getTeamManager().playerLeaveTeam(this, teamPlayer);
 		}
 
 		// removing it from the team list, the java GC will handle the reset
@@ -756,8 +761,8 @@ public class Team {
 
 		if (Main.plugin.getConfig().getBoolean("announceTeamDisband")) {
 			Message message = new ReferencedFormatMessage("announce.disband", getColor() + getName() + ChatColor.RESET);
-			for (Player player : Bukkit.getOnlinePlayers()) {
-				message.sendMessage(player);
+			for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+				message.sendMessage(onlinePlayer);
 			}
 		}
 	}

--- a/src/main/java/com/booksaw/betterTeams/commands/team/DisbandCommand.java
+++ b/src/main/java/com/booksaw/betterTeams/commands/team/DisbandCommand.java
@@ -33,7 +33,7 @@ public class DisbandCommand extends TeamSubCommand {
 
 		// can use secret command /team disband confirm to validate disband success
 		if (args.length > 1 && args[0].equals("confirm")) {
-			team.disband();
+			team.disband(teamPlayer.getPlayer().getPlayer());
 			confirmation.remove(found);
 			return new CommandResponse(true, "disband.success");
 		}
@@ -46,7 +46,7 @@ public class DisbandCommand extends TeamSubCommand {
 		}
 
 		if (found != null) {
-			team.disband();
+			team.disband(teamPlayer.getPlayer().getPlayer());
 			confirmation.remove(found);
 			return new CommandResponse(true, "disband.success");
 		}

--- a/src/main/java/com/booksaw/betterTeams/commands/teama/DisbandTeama.java
+++ b/src/main/java/com/booksaw/betterTeams/commands/teama/DisbandTeama.java
@@ -5,6 +5,7 @@ import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.commands.presets.TeamSelectSubCommand;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import java.util.List;
 
@@ -12,8 +13,11 @@ public class DisbandTeama extends TeamSelectSubCommand {
 
 	@Override
 	public CommandResponse onCommand(CommandSender sender, String label, String[] args, Team team) {
-
-		team.disband();
+		if (sender instanceof Player) {
+			team.disband((Player)sender);
+		} else {
+			team.disband();
+		}
 
 		return new CommandResponse(true, "admin.disband.success");
 	}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/CreateTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/CreateTeamEvent.java
@@ -1,6 +1,8 @@
 package com.booksaw.betterTeams.customEvents;
 
 import com.booksaw.betterTeams.Team;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,9 +12,11 @@ import org.jetbrains.annotations.NotNull;
 public class CreateTeamEvent extends TeamEvent {
 
     private static final HandlerList HANDLERS = new HandlerList();
+    private final Player player;
 
-    public CreateTeamEvent(Team team) {
+    public CreateTeamEvent(Team team, Player player) {
         super(team);
+        this.player = player;
     }
 
     public static HandlerList getHandlerList() {
@@ -22,6 +26,10 @@ public class CreateTeamEvent extends TeamEvent {
     @Override
     public @NotNull HandlerList getHandlers() {
         return HANDLERS;
+    }
+
+    public Player getPlayer() {
+        return player;
     }
 
 }

--- a/src/main/java/com/booksaw/betterTeams/customEvents/DisbandTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/DisbandTeamEvent.java
@@ -1,15 +1,20 @@
 package com.booksaw.betterTeams.customEvents;
 
 import com.booksaw.betterTeams.Team;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class DisbandTeamEvent extends TeamEvent {
 
 	private static final HandlerList HANDLERS = new HandlerList();
+	private final Player player;
 
-	public DisbandTeamEvent(Team team) {
+	public DisbandTeamEvent(Team team, @Nullable Player player) {
 		super(team);
+		this.player = player;
 	}
 
 	public static HandlerList getHandlerList() {
@@ -19,6 +24,11 @@ public class DisbandTeamEvent extends TeamEvent {
 	@Override
 	public @NotNull HandlerList getHandlers() {
 		return HANDLERS;
+	}
+
+	@Nullable
+	public Player getPlayer() {
+		return player;
 	}
 
 }

--- a/src/main/java/com/booksaw/betterTeams/integrations/WorldGuardManagerV7.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/WorldGuardManagerV7.java
@@ -17,11 +17,11 @@ import org.bukkit.entity.Player;
 
 import java.util.logging.Level;
 
-public class WorldGaurdManagerV7 {
+public class WorldGuardManagerV7 {
 
 	public static StateFlag TEAM_PVP_FLAG;
 
-	public WorldGaurdManagerV7() {
+	public WorldGuardManagerV7() {
 
 		FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
 

--- a/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
@@ -169,7 +169,7 @@ public abstract class TeamManager {
 		}
 		Team team = new Team(name, id, owner);
 
-		CreateTeamEvent event = new CreateTeamEvent(team);
+		CreateTeamEvent event = new CreateTeamEvent(team, owner);
 		Bukkit.getPluginManager().callEvent(event);
 
 		if (event.isCancelled()) {


### PR DESCRIPTION
- Allows developers to catch players responsible for creating or disbanding teams.
- Updates a few dependencies so the project can be compiled on fresh machines.
- Replaces a Java 11+ Nullable import to restore Java 8 compatibility.
- Fixes a spelling error in one class name.