### PR TITLE
refactor: streamline team disband confirmation flow

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/commands/team/DisbandCommand.java
+++ b/src/main/java/com/booksaw/betterTeams/commands/team/DisbandCommand.java
@@ -9,7 +9,6 @@ import org.bukkit.command.CommandSender;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.UUID;
 
 /**
@@ -29,7 +28,7 @@ public class DisbandCommand extends TeamSubCommand {
 	public CommandResponse onCommand(TeamPlayer teamPlayer, String label, String[] args, Team team) {
 		UUID playerId = teamPlayer.getPlayer().getUniqueId();
 
-		if ((args.length > 1 && args[0].equals("confirm")) ||
+		if ((args.length >= 1 && args[0].equals("confirm")) ||
 			(System.currentTimeMillis() - confirmation.getOrDefault(playerId, 0L) < 10000)) {
 
 			team.disband(teamPlayer.getPlayer().getPlayer());

--- a/src/main/java/com/booksaw/betterTeams/commands/team/DisbandCommand.java
+++ b/src/main/java/com/booksaw/betterTeams/commands/team/DisbandCommand.java
@@ -27,33 +27,18 @@ public class DisbandCommand extends TeamSubCommand {
 
 	@Override
 	public CommandResponse onCommand(TeamPlayer teamPlayer, String label, String[] args, Team team) {
+		UUID playerId = teamPlayer.getPlayer().getUniqueId();
 
-		UUID found = null;
-		// if they have already had the confirm dialogue
+		if ((args.length > 1 && args[0].equals("confirm")) ||
+			(System.currentTimeMillis() - confirmation.getOrDefault(playerId, 0L) < 10000)) {
 
-		// can use secret command /team disband confirm to validate disband success
-		if (args.length > 1 && args[0].equals("confirm")) {
 			team.disband(teamPlayer.getPlayer().getPlayer());
-			confirmation.remove(found);
+			confirmation.remove(playerId);
 			return new CommandResponse(true, "disband.success");
 		}
 
-		for (Entry<UUID, Long> temp : confirmation.entrySet()) {
-			if (temp.getKey().compareTo(teamPlayer.getPlayer().getUniqueId()) == 0
-					&& temp.getValue() < System.currentTimeMillis() + 10000) {
-				found = temp.getKey();
-			}
-		}
-
-		if (found != null) {
-			team.disband(teamPlayer.getPlayer().getPlayer());
-			confirmation.remove(found);
-			return new CommandResponse(true, "disband.success");
-		}
-
-		confirmation.put(teamPlayer.getPlayer().getUniqueId(), System.currentTimeMillis());
+		confirmation.put(playerId, System.currentTimeMillis());
 		return new CommandResponse("disband.confirm");
-
 	}
 
 	@Override


### PR DESCRIPTION
Simplifies the team disband confirmation logic by removing redundant code paths.

No change in behavior