### PR TITLE
feat: Implement post-event system for team actions

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/Main.java
+++ b/src/main/java/com/booksaw/betterTeams/Main.java
@@ -357,6 +357,7 @@ public class Main extends JavaPlugin {
 		getServer().getPluginManager().registerEvents((chatManagement = new ChatManagement()), this);
 		getServer().getPluginManager().registerEvents(new ScoreManagement(), this);
 		getServer().getPluginManager().registerEvents(new AllyManagement(), this);
+		getServer().getPluginManager().registerEvents(new MessagesManagement(), this);
 
 		if (getConfig().getBoolean("checkUpdates")) {
 			getServer().getPluginManager().registerEvents(new UpdateChecker(this), this);

--- a/src/main/java/com/booksaw/betterTeams/commands/team/DepositCommand.java
+++ b/src/main/java/com/booksaw/betterTeams/commands/team/DepositCommand.java
@@ -4,6 +4,7 @@ import com.booksaw.betterTeams.*;
 import com.booksaw.betterTeams.commands.ParentCommand;
 import com.booksaw.betterTeams.commands.presets.TeamSubCommand;
 import com.booksaw.betterTeams.customEvents.TeamDepositEvent;
+import com.booksaw.betterTeams.customEvents.post.PostTeamDepositEvent;
 import com.booksaw.betterTeams.message.HelpMessage;
 import net.milkbowl.vault.economy.EconomyResponse;
 import org.bukkit.Bukkit;
@@ -56,6 +57,8 @@ public class DepositCommand extends TeamSubCommand {
 		}
 
 		team.setMoney(result);
+
+		Bukkit.getPluginManager().callEvent(new PostTeamDepositEvent(team, player, amount));
 
 		return new CommandResponse(true, "deposit.success");
 	}

--- a/src/main/java/com/booksaw/betterTeams/commands/team/RankupCommand.java
+++ b/src/main/java/com/booksaw/betterTeams/commands/team/RankupCommand.java
@@ -3,9 +3,11 @@ package com.booksaw.betterTeams.commands.team;
 import com.booksaw.betterTeams.*;
 import com.booksaw.betterTeams.commands.presets.TeamSubCommand;
 import com.booksaw.betterTeams.customEvents.LevelupTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostLevelupTeamEvent;
 import com.booksaw.betterTeams.message.ReferencedFormatMessage;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 
 import java.util.List;
 
@@ -48,8 +50,10 @@ public class RankupCommand extends TeamSubCommand {
 
 		}
 
-		LevelupTeamEvent event = new LevelupTeamEvent(team, team.getLevel(), team.getLevel() + 1, price, score,
-				player.getPlayer().getPlayer());
+		int oldLevel = team.getLevel();
+		int newLevel = oldLevel + 1;
+		Player mcPlayer = player.getPlayer().getPlayer();
+		LevelupTeamEvent event = new LevelupTeamEvent(team, oldLevel, newLevel, price, score, mcPlayer);
 		Bukkit.getPluginManager().callEvent(event);
 		if (event.isCancelled()) {
 			return new CommandResponse(false);
@@ -61,8 +65,9 @@ public class RankupCommand extends TeamSubCommand {
 			team.setMoney(team.getMoney() - price);
 		}
 
-		team.setLevel(team.getLevel() + 1);
+		team.setLevel(newLevel);
 
+		Bukkit.getPluginManager().callEvent(new PostLevelupTeamEvent(team, oldLevel, newLevel, price, score, mcPlayer));
 		return new CommandResponse(true, "rankup.success");
 	}
 

--- a/src/main/java/com/booksaw/betterTeams/commands/team/WithdrawCommand.java
+++ b/src/main/java/com/booksaw/betterTeams/commands/team/WithdrawCommand.java
@@ -4,6 +4,7 @@ import com.booksaw.betterTeams.*;
 import com.booksaw.betterTeams.commands.ParentCommand;
 import com.booksaw.betterTeams.commands.presets.TeamSubCommand;
 import com.booksaw.betterTeams.customEvents.TeamWithdrawEvent;
+import com.booksaw.betterTeams.customEvents.post.PostTeamWithdrawEvent;
 import com.booksaw.betterTeams.message.HelpMessage;
 import net.milkbowl.vault.economy.EconomyResponse;
 import org.bukkit.Bukkit;
@@ -55,6 +56,8 @@ public class WithdrawCommand extends TeamSubCommand {
 		}
 
 		team.setMoney(team.getMoney() - amount);
+
+		Bukkit.getPluginManager().callEvent(new PostTeamWithdrawEvent(team, player, amount));
 
 		return new CommandResponse(true, "withdraw.success");
 	}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/DisbandTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/DisbandTeamEvent.java
@@ -1,7 +1,6 @@
 package com.booksaw.betterTeams.customEvents;
 
 import com.booksaw.betterTeams.Team;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/booksaw/betterTeams/customEvents/TeamNameChangeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/TeamNameChangeEvent.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class TeamNameChangeEvent extends TeamEvent {
     private String newName;
+
     public TeamNameChangeEvent(@NotNull Team team,
                                @NotNull String newName) {
         super(team);

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostCreateTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostCreateTeamEvent.java
@@ -1,0 +1,35 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.customEvents.TeamEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An event which is called right before the creation of a {@link Team}
+ */
+public class PostCreateTeamEvent extends TeamEvent {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final Player player;
+
+    public PostCreateTeamEvent(Team team, Player player) {
+        super(team, true);
+        this.player = player;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostCreateTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostCreateTeamEvent.java
@@ -7,7 +7,12 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An event which is called right before the creation of a {@link Team}
+ * An event which is called immediately after a {@link Team} is successfully created.
+ * This event cannot be cancelled since it occurs after the team creation.
+ *
+ * To modify or cancel the team creation, use {@link CreateTeamEvent}.
+ *
+ * @author svaningelgem
  */
 public class PostCreateTeamEvent extends TeamEvent {
 

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostDemotePlayerEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostDemotePlayerEvent.java
@@ -1,0 +1,27 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.PlayerRank;
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.customEvents.RankChangePlayerEvent;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class PostDemotePlayerEvent extends RankChangePlayerEvent {
+
+	public PostDemotePlayerEvent(Team team, TeamPlayer teamPlayer, PlayerRank currentRank, PlayerRank newRank) {
+		super(team, teamPlayer, currentRank, newRank);
+	}
+
+	private static final HandlerList HANDLERS = new HandlerList();
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostDemotePlayerEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostDemotePlayerEvent.java
@@ -7,6 +7,15 @@ import com.booksaw.betterTeams.customEvents.RankChangePlayerEvent;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * An event which is called after a player's rank has been lowered within their team.
+ * This event tracks both the previous and new rank of the affected player.
+ * This event cannot be cancelled since it occurs after the demotion.
+ *
+ * To modify or cancel the demotion, use {@link DemotePlayerEvent}.
+ *
+ * @author svaningelgem
+ */
 public class PostDemotePlayerEvent extends RankChangePlayerEvent {
 
 	public PostDemotePlayerEvent(Team team, TeamPlayer teamPlayer, PlayerRank currentRank, PlayerRank newRank) {

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostDisbandTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostDisbandTeamEvent.java
@@ -12,6 +12,16 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * An event which is called after a team has been disbanded.
+ * Contains information about the player who disbanded the team (if applicable),
+ * the team's previous allies, and all former team members.
+ * This event cannot be cancelled since it occurs after the disbanding.
+ *
+ * To modify or cancel the disbanding, use {@link DisbandTeamEvent}.
+ *
+ * @author svaningelgem
+ */
 public class PostDisbandTeamEvent extends TeamEvent {
 
 	private static final HandlerList HANDLERS = new HandlerList();

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostDisbandTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostDisbandTeamEvent.java
@@ -1,0 +1,63 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.customEvents.TeamEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+public class PostDisbandTeamEvent extends TeamEvent {
+
+	private static final HandlerList HANDLERS = new HandlerList();
+	private final Player player;
+	private final Set<UUID> prevAllies;
+	private final Set<TeamPlayer> prevMembers;
+	private Set<Team> processedAllies = null;
+
+	public PostDisbandTeamEvent(Team team, @Nullable Player player, Set<UUID> previousAllies, Set<TeamPlayer> previousMembers) {
+		super(team, true);
+		this.player = player;
+		this.prevAllies = previousAllies;
+		this.prevMembers = previousMembers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+	@Nullable
+	public Player getPlayer() {
+		return player;
+	}
+
+	@NotNull
+	public Set<Team> getAllies() {
+		if (processedAllies == null) {
+			processedAllies = new HashSet<>();
+			for (UUID uuid : prevAllies) {
+				Team team = Team.getTeam(uuid);
+				if (team != null) {
+					processedAllies.add(team);
+				}
+			}
+		}
+
+		return processedAllies;
+	}
+
+	@NotNull
+	public Set<TeamPlayer> getMembers() {
+		return prevMembers;
+	}
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostLevelupTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostLevelupTeamEvent.java
@@ -6,6 +6,16 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * An event which is called after a team's level has been increased.
+ * Contains information about the previous and new levels, the cost of the levelup,
+ * whether score was used for payment, and the player who initiated the levelup.
+ * This event cannot be cancelled since it occurs after the level increase.
+ *
+ * To modify or cancel the level up, use {@link LevelupTeamEvent}.
+ *
+ * @author svaningelgem
+ */
 public class PostLevelupTeamEvent extends TeamEvent {
 
 	private static final HandlerList HANDLERS = new HandlerList();

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostLevelupTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostLevelupTeamEvent.java
@@ -1,0 +1,56 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.customEvents.TeamEvent;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class PostLevelupTeamEvent extends TeamEvent {
+
+	private static final HandlerList HANDLERS = new HandlerList();
+	private final int currentLevel;
+	private final int newLevel;
+	private final int cost;
+	private final boolean score;
+	private final Player commandSender;
+
+	public PostLevelupTeamEvent(Team team, int currentLevel, int newLevel, int cost, boolean score, Player commandSender) {
+		super(team, true);
+		this.currentLevel = currentLevel;
+		this.newLevel = newLevel;
+		this.cost = cost;
+		this.score = score;
+		this.commandSender = commandSender;
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+	public int getCurrentLevel() {
+		return currentLevel;
+	}
+
+	public int getNewLevel() {
+		return newLevel;
+	}
+
+	public int getCost() {
+		return cost;
+	}
+
+	public boolean isScore() {
+		return score;
+	}
+
+	public Player getCommandSender() {
+		return commandSender;
+	}
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPlayerJoinTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPlayerJoinTeamEvent.java
@@ -7,9 +7,12 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Called when a player joins a team
+ * Called after a player has successfully joined a team.
+ * This event cannot be cancelled since it occurs after the player has joined.
  *
- * @author booksaw
+ * To modify or cancel the join action, use {@link PlayerJoinTeamEvent}.
+ *
+ * @author svaningelgem
  */
 public class PostPlayerJoinTeamEvent extends TeamPlayerEvent {
 

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPlayerJoinTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPlayerJoinTeamEvent.java
@@ -1,0 +1,31 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.customEvents.TeamPlayerEvent;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Called when a player joins a team
+ *
+ * @author booksaw
+ */
+public class PostPlayerJoinTeamEvent extends TeamPlayerEvent {
+
+	private static final HandlerList HANDLERS = new HandlerList();
+
+	public PostPlayerJoinTeamEvent(Team team, TeamPlayer teamPlayer) {
+		super(team, teamPlayer, true);
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPlayerLeaveTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPlayerLeaveTeamEvent.java
@@ -6,6 +6,14 @@ import com.booksaw.betterTeams.customEvents.TeamPlayerEvent;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * An event which is called after a player has left their team.
+ * This event cannot be cancelled since it occurs after the player has left.
+ *
+ * To modify or cancel the leave action, use {@link PlayerLeaveTeamEvent}.
+ *
+ * @author svaningelgem
+ */
 public class PostPlayerLeaveTeamEvent extends TeamPlayerEvent {
 
 	private static final HandlerList HANDLERS = new HandlerList();

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPlayerLeaveTeamEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPlayerLeaveTeamEvent.java
@@ -1,0 +1,26 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.customEvents.TeamPlayerEvent;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class PostPlayerLeaveTeamEvent extends TeamPlayerEvent {
+
+	private static final HandlerList HANDLERS = new HandlerList();
+
+	public PostPlayerLeaveTeamEvent(Team team, TeamPlayer teamPlayer) {
+		super(team, teamPlayer, true);
+	}
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPromotePlayerEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPromotePlayerEvent.java
@@ -7,6 +7,15 @@ import com.booksaw.betterTeams.customEvents.RankChangePlayerEvent;
 import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * An event which is called after a player's rank has been increased within their team.
+ * This event tracks both the previous and new rank of the affected player.
+ * This event cannot be cancelled since it occurs after the promotion.
+ *
+ * To modify or cancel the promotion, use {@link PromotePlayerEvent}.
+ *
+ * @author svaningelgem
+ */
 public class PostPromotePlayerEvent extends RankChangePlayerEvent {
 
 	public PostPromotePlayerEvent(Team team, TeamPlayer teamPlayer, PlayerRank currentRank, PlayerRank newRank) {

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPromotePlayerEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPromotePlayerEvent.java
@@ -1,0 +1,27 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.PlayerRank;
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.customEvents.RankChangePlayerEvent;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class PostPromotePlayerEvent extends RankChangePlayerEvent {
+
+	public PostPromotePlayerEvent(Team team, TeamPlayer teamPlayer, PlayerRank currentRank, PlayerRank newRank) {
+		super(team, teamPlayer, currentRank, newRank);
+	}
+
+	private static final HandlerList HANDLERS = new HandlerList();
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPurgeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPurgeEvent.java
@@ -35,8 +35,7 @@ public class PostPurgeEvent extends Event implements Cancellable {
 
 	@Override
 	public void setCancelled(boolean b) {
-		cancelled = b;
-
+		throw new UnsupportedOperationException("You can't cancel a post event.");
 	}
 
 }

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPurgeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPurgeEvent.java
@@ -1,0 +1,42 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This command is called just before a purge occurs
+ *
+ * @author booksaw
+ */
+public class PostPurgeEvent extends Event implements Cancellable {
+
+	private static final HandlerList HANDLERS = new HandlerList();
+	private boolean cancelled = false;
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+	public PostPurgeEvent() {
+		super(true);
+	}
+	
+	@Override
+	public @NotNull HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+	@Override
+	public boolean isCancelled() {
+		return cancelled;
+	}
+
+	@Override
+	public void setCancelled(boolean b) {
+		cancelled = b;
+
+	}
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPurgeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostPurgeEvent.java
@@ -6,9 +6,12 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * This command is called just before a purge occurs
+ * This event is called after a team purge has been completed.
+ * This event cannot be cancelled since it occurs after the purge.
  *
- * @author booksaw
+ * To modify or cancel the purge, use {@link PurgeEvent}.
+ *
+ * @author svaningelgem
  */
 public class PostPurgeEvent extends Event implements Cancellable {
 

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamColorChangeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamColorChangeEvent.java
@@ -7,7 +7,13 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An event which is called right before the recoloring of a {@link Team}
+ * An event which is called after a {@link Team}'s color has been changed.
+ * Contains information about both the old and new team colors.
+ * This event cannot be cancelled since it occurs after the color change.
+ *
+ * To modify or cancel the color change, use {@link TeamColorChangeEvent}.
+ *
+ * @author svaningelgem
  */
 public class PostTeamColorChangeEvent extends TeamEvent {
     private final ChatColor oldColor;

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamColorChangeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamColorChangeEvent.java
@@ -1,0 +1,44 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.customEvents.TeamEvent;
+import org.bukkit.ChatColor;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An event which is called right before the recoloring of a {@link Team}
+ */
+public class PostTeamColorChangeEvent extends TeamEvent {
+    private final ChatColor oldColor;
+    private final ChatColor newColor;
+
+    public PostTeamColorChangeEvent(@NotNull Team team,
+                                    @NotNull ChatColor oldColor,
+                                    @NotNull ChatColor newColor) {
+        super(team, true);
+        this.oldColor = oldColor;
+        this.newColor = newColor;
+    }
+
+    public ChatColor getOldTeamColor() {
+        return oldColor;
+    }
+
+    public ChatColor getNewTeamColor() {
+        return newColor;
+    }
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamDepositEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamDepositEvent.java
@@ -8,7 +8,13 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An event which is called when a player deposits money into their {@link Team}'s balance
+ * An event which is called after a player has deposited money into their {@link Team}'s balance.
+ * Contains information about the amount deposited and the player who made the deposit.
+ * This event cannot be cancelled since it occurs after the deposit.
+ *
+ * To modify or cancel the deposit, use {@link TeamDepositEvent}.
+ *
+ * @author svaningelgem
  */
 public final class PostTeamDepositEvent extends TeamPlayerEvent implements TeamMoneyEvent {
     private static final HandlerList HANDLERS = new HandlerList();

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamDepositEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamDepositEvent.java
@@ -1,0 +1,42 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.customEvents.TeamMoneyEvent;
+import com.booksaw.betterTeams.customEvents.TeamPlayerEvent;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An event which is called when a player deposits money into their {@link Team}'s balance
+ */
+public final class PostTeamDepositEvent extends TeamPlayerEvent implements TeamMoneyEvent {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final double amount;
+
+    public PostTeamDepositEvent(final Team team, final TeamPlayer teamPlayer, final double amount) {
+        super(team, teamPlayer, false);
+
+        this.amount = amount;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @Override
+    public double getAmount() {
+        return this.amount;
+    }
+
+    @Override
+    public void setAmount(final double amount) {
+        throw new UnsupportedOperationException("You can't change the amount in a post event.");
+    }
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamNameChangeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamNameChangeEvent.java
@@ -6,7 +6,13 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An event which is called right before the renaming of a {@link Team}
+ * An event which is called after a {@link Team}'s name has been changed.
+ * Contains information about both the old and new team names.
+ * This event cannot be cancelled since it occurs after the name change.
+ *
+ * To modify or cancel the name change, use {@link TeamNameChangeEvent}.
+ *
+ * @author svaningelgem
  */
 public class PostTeamNameChangeEvent extends TeamEvent {
 	private final String oldName;

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamNameChangeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamNameChangeEvent.java
@@ -1,0 +1,41 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.customEvents.TeamEvent;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An event which is called right before the renaming of a {@link Team}
+ */
+public class PostTeamNameChangeEvent extends TeamEvent {
+	private final String oldName;
+	private final String newName;
+
+	public PostTeamNameChangeEvent(@NotNull Team team, @NotNull String oldName, @NotNull String newName) {
+		super(team);
+		this.oldName = oldName;
+		this.newName = newName;
+	}
+
+	public String getOldTeamName() {
+		return oldName;
+	}
+
+	public String getNewTeamName() {
+		return newName;
+	}
+
+	private static final HandlerList HANDLERS = new HandlerList();
+
+	public static HandlerList getHandlerList() {
+		return HANDLERS;
+	}
+
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return HANDLERS;
+	}
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamTagChangeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamTagChangeEvent.java
@@ -6,7 +6,13 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An event which is called right before the tag of a {@link Team} is changed
+ * An event which is called after a {@link Team}'s tag has been changed.
+ * Contains information about both the old and new team tags.
+ * This event cannot be cancelled since it occurs after the tag change.
+ *
+ * To modify or cancel the tag change, use {@link TeamTagChangeEvent}.
+ *
+ * @author svaningelgem
  */
 public class PostTeamTagChangeEvent extends TeamEvent {
     private final String oldTag;

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamTagChangeEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamTagChangeEvent.java
@@ -1,0 +1,43 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.customEvents.TeamEvent;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An event which is called right before the tag of a {@link Team} is changed
+ */
+public class PostTeamTagChangeEvent extends TeamEvent {
+    private final String oldTag;
+    private final String newTag;
+
+    public PostTeamTagChangeEvent(@NotNull Team team,
+                                  @NotNull String oldTag,
+                                  @NotNull String newTag) {
+        super(team, true);
+        this.oldTag = oldTag;
+        this.newTag = newTag;
+    }
+
+    public String getOldTeamTag() {
+        return oldTag;
+    }
+
+    public String getNewTeamTag() {
+        return newTag;
+    }
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamWithdrawEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamWithdrawEvent.java
@@ -1,0 +1,42 @@
+package com.booksaw.betterTeams.customEvents.post;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.customEvents.TeamMoneyEvent;
+import com.booksaw.betterTeams.customEvents.TeamPlayerEvent;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * An event which is called when a player withdraws money from their {@link Team}'s balance
+ */
+public final class PostTeamWithdrawEvent extends TeamPlayerEvent implements TeamMoneyEvent {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final double amount;
+
+    public PostTeamWithdrawEvent(final Team team, final TeamPlayer teamPlayer, final double amount) {
+        super(team, teamPlayer, false);
+
+        this.amount = amount;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    @Override
+    public @NotNull HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    @Override
+    public double getAmount() {
+        return this.amount;
+    }
+
+    @Override
+    public void setAmount(double amount) {
+        throw new UnsupportedOperationException("You can't change the amount in a post event.");
+    }
+}

--- a/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamWithdrawEvent.java
+++ b/src/main/java/com/booksaw/betterTeams/customEvents/post/PostTeamWithdrawEvent.java
@@ -8,7 +8,13 @@ import org.bukkit.event.HandlerList;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An event which is called when a player withdraws money from their {@link Team}'s balance
+ * An event which is called after a player has withdrawn money from their {@link Team}'s balance.
+ * Contains information about the amount withdrawn and the player who made the withdrawal.
+ * This event cannot be cancelled since it occurs after the withdrawal.
+ *
+ * To modify or cancel the withdrawal, use {@link TeamWithdrawEvent}.
+ *
+ * @author svaningelgem
  */
 public final class PostTeamWithdrawEvent extends TeamPlayerEvent implements TeamMoneyEvent {
     private static final HandlerList HANDLERS = new HandlerList();

--- a/src/main/java/com/booksaw/betterTeams/events/MCTeamManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/MCTeamManagement.java
@@ -125,7 +125,6 @@ public class MCTeamManagement implements Listener {
 
 		BelowNameChangeEvent event = new BelowNameChangeEvent(player, ChangeType.REMOVE, isAsync);
 		Bukkit.getPluginManager().callEvent(event);
-
 	}
 
 	@EventHandler

--- a/src/main/java/com/booksaw/betterTeams/events/MessagesManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/MessagesManagement.java
@@ -1,0 +1,45 @@
+package com.booksaw.betterTeams.events;
+
+import com.booksaw.betterTeams.Main;
+import com.booksaw.betterTeams.customEvents.post.PostDisbandTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPlayerJoinTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPlayerLeaveTeamEvent;
+import com.booksaw.betterTeams.message.Message;
+import com.booksaw.betterTeams.message.ReferencedFormatMessage;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class MessagesManagement implements Listener {
+	@EventHandler
+	public void onPostPlayerJoinTeamEvent(PostPlayerJoinTeamEvent e) {
+		if (Main.plugin.getConfig().getBoolean("announceTeamJoin")) {
+			Message message = new ReferencedFormatMessage("announce.join", e.getPlayer().getName(), e.getTeam().getColor() + e.getTeam().getName() + ChatColor.RESET);
+			for (Player player : Bukkit.getOnlinePlayers()) {
+				message.sendMessage(player);
+			}
+		}
+	}
+
+	@EventHandler
+	public void onPostDisbandTeamEvent(PostDisbandTeamEvent e) {
+		if (Main.plugin.getConfig().getBoolean("announceTeamDisband")) {
+			Message message = new ReferencedFormatMessage("announce.disband", e.getTeam().getColor() + e.getTeam().getName() + ChatColor.RESET);
+			for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+				message.sendMessage(onlinePlayer);
+			}
+		}
+	}
+
+	@EventHandler
+	public void onPostPlayerLeaveTeamEvent(PostPlayerLeaveTeamEvent e) {
+		if (Main.plugin.getConfig().getBoolean("announceTeamLeave")) {
+			Message message = new ReferencedFormatMessage("announce.leave", e.getPlayer().getName(), e.getTeam().getColor() + e.getTeam().getName() + ChatColor.RESET);
+			for (Player player : Bukkit.getOnlinePlayers()) {
+				message.sendMessage(player);
+			}
+		}
+	}
+}

--- a/src/main/java/com/booksaw/betterTeams/events/MessagesManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/MessagesManagement.java
@@ -1,9 +1,8 @@
 package com.booksaw.betterTeams.events;
 
 import com.booksaw.betterTeams.Main;
-import com.booksaw.betterTeams.customEvents.post.PostDisbandTeamEvent;
-import com.booksaw.betterTeams.customEvents.post.PostPlayerJoinTeamEvent;
-import com.booksaw.betterTeams.customEvents.post.PostPlayerLeaveTeamEvent;
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.customEvents.post.*;
 import com.booksaw.betterTeams.message.Message;
 import com.booksaw.betterTeams.message.ReferencedFormatMessage;
 import org.bukkit.Bukkit;
@@ -11,35 +10,56 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class MessagesManagement implements Listener {
-	@EventHandler
-	public void onPostPlayerJoinTeamEvent(PostPlayerJoinTeamEvent e) {
-		if (Main.plugin.getConfig().getBoolean("announceTeamJoin")) {
-			Message message = new ReferencedFormatMessage("announce.join", e.getPlayer().getName(), e.getTeam().getColor() + e.getTeam().getName() + ChatColor.RESET);
-			for (Player player : Bukkit.getOnlinePlayers()) {
-				message.sendMessage(player);
-			}
+
+	private enum TeamAnnouncement {
+		JOIN("announceTeamJoin", "announce.join"),
+		LEAVE("announceTeamLeave", "announce.leave"),
+		DISBAND("announceTeamDisband", "announce.disband");
+
+		private final String configKey;
+		private final String messageKey;
+
+		TeamAnnouncement(String configKey, String messageKey) {
+			this.configKey = configKey;
+			this.messageKey = messageKey;
+		}
+	}
+
+	private void broadcastTeamMessage(@NotNull TeamAnnouncement type, @NotNull Team team, @Nullable String playerName) {
+		if (!Main.plugin.getConfig().getBoolean(type.configKey)) {
+			return;
+		}
+
+		Message message;
+		String coloredTeamName = team.getColor() + team.getName() + ChatColor.RESET;
+
+		if (playerName != null) {
+			message = new ReferencedFormatMessage(type.messageKey, playerName, coloredTeamName);
+		} else {
+			message = new ReferencedFormatMessage(type.messageKey, coloredTeamName);
+		}
+
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			message.sendMessage(player);
 		}
 	}
 
 	@EventHandler
-	public void onPostDisbandTeamEvent(PostDisbandTeamEvent e) {
-		if (Main.plugin.getConfig().getBoolean("announceTeamDisband")) {
-			Message message = new ReferencedFormatMessage("announce.disband", e.getTeam().getColor() + e.getTeam().getName() + ChatColor.RESET);
-			for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-				message.sendMessage(onlinePlayer);
-			}
-		}
+	public void onPostPlayerJoinTeamEvent(@NotNull PostPlayerJoinTeamEvent e) {
+		broadcastTeamMessage(TeamAnnouncement.JOIN, e.getTeam(), e.getPlayer().getName());
 	}
 
 	@EventHandler
-	public void onPostPlayerLeaveTeamEvent(PostPlayerLeaveTeamEvent e) {
-		if (Main.plugin.getConfig().getBoolean("announceTeamLeave")) {
-			Message message = new ReferencedFormatMessage("announce.leave", e.getPlayer().getName(), e.getTeam().getColor() + e.getTeam().getName() + ChatColor.RESET);
-			for (Player player : Bukkit.getOnlinePlayers()) {
-				message.sendMessage(player);
-			}
-		}
+	public void onPostPlayerLeaveTeamEvent(@NotNull PostPlayerLeaveTeamEvent e) {
+		broadcastTeamMessage(TeamAnnouncement.LEAVE, e.getTeam(), e.getPlayer().getName());
+	}
+
+	@EventHandler
+	public void onPostDisbandTeamEvent(@NotNull PostDisbandTeamEvent e) {
+		broadcastTeamMessage(TeamAnnouncement.DISBAND, e.getTeam(), null);
 	}
 }

--- a/src/main/java/com/booksaw/betterTeams/events/RankupEvents.java
+++ b/src/main/java/com/booksaw/betterTeams/events/RankupEvents.java
@@ -3,9 +3,9 @@ package com.booksaw.betterTeams.events;
 import com.booksaw.betterTeams.Main;
 import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.TeamPlayer;
-import com.booksaw.betterTeams.customEvents.DemotePlayerEvent;
-import com.booksaw.betterTeams.customEvents.LevelupTeamEvent;
 import com.booksaw.betterTeams.customEvents.PromotePlayerEvent;
+import com.booksaw.betterTeams.customEvents.post.PostDemotePlayerEvent;
+import com.booksaw.betterTeams.customEvents.post.PostLevelupTeamEvent;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -20,7 +20,7 @@ import java.util.Objects;
 public class RankupEvents implements Listener {
 
 	@EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-	public void onRankup(LevelupTeamEvent e) {
+	public void onRankup(PostLevelupTeamEvent e) {
 		List<String> endCommands = Main.plugin.getConfig()
 				.getStringList("levels.l" + e.getCurrentLevel() + ".endCommands");
 		runCommandList(endCommands, e.getTeam(), e.getCurrentLevel() + "", e.getCommandSender());
@@ -37,7 +37,7 @@ public class RankupEvents implements Listener {
 	}
 
 	@EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-	public void onDemote(DemotePlayerEvent e) {
+	public void onDemote(PostDemotePlayerEvent e) {
 		List<String> commands = Main.plugin.getConfig().getStringList("demoteCommands." + e.getNewRank().toString().toUpperCase());
 		runCommandList(commands, e.getTeam(), e.getNewRank().toString(), e.getPlayer());
 	}

--- a/src/main/java/com/booksaw/betterTeams/events/RankupEvents.java
+++ b/src/main/java/com/booksaw/betterTeams/events/RankupEvents.java
@@ -6,6 +6,7 @@ import com.booksaw.betterTeams.TeamPlayer;
 import com.booksaw.betterTeams.customEvents.PromotePlayerEvent;
 import com.booksaw.betterTeams.customEvents.post.PostDemotePlayerEvent;
 import com.booksaw.betterTeams.customEvents.post.PostLevelupTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPromotePlayerEvent;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -31,7 +32,7 @@ public class RankupEvents implements Listener {
 	}
 
 	@EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
-	public void onPromote(PromotePlayerEvent e) {
+	public void onPromote(PostPromotePlayerEvent e) {
 		List<String> commands = Main.plugin.getConfig().getStringList("promoteCommands." + e.getNewRank().toString().toUpperCase());
 		runCommandList(commands, e.getTeam(), e.getNewRank().toString(), e.getPlayer());
 	}

--- a/src/main/java/com/booksaw/betterTeams/integrations/UltimateClaimsManager.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/UltimateClaimsManager.java
@@ -4,9 +4,9 @@ import com.booksaw.betterTeams.Main;
 import com.booksaw.betterTeams.PlayerRank;
 import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.TeamPlayer;
-import com.booksaw.betterTeams.customEvents.DisbandTeamEvent;
-import com.booksaw.betterTeams.customEvents.PlayerJoinTeamEvent;
-import com.booksaw.betterTeams.customEvents.PlayerLeaveTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostDisbandTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPlayerJoinTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPlayerLeaveTeamEvent;
 import com.booksaw.betterTeams.message.MessageManager;
 import com.craftaro.ultimateclaims.UltimateClaims;
 import com.craftaro.ultimateclaims.api.events.*;
@@ -65,7 +65,7 @@ public class UltimateClaimsManager implements Listener {
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	public void onJoin(PlayerJoinTeamEvent e) {
+	public void onJoin(PostPlayerJoinTeamEvent e) {
 		List<TeamPlayer> players = e.getTeam().getRank(PlayerRank.OWNER);
 
 		for (TeamPlayer player : players) {
@@ -82,12 +82,11 @@ public class UltimateClaimsManager implements Listener {
 					JavaPlugin.getPlugin(UltimateClaims.class).getDataHelper().createMember(member);
 				}
 			}.runTaskLater(Main.plugin, 1);
-
 		}
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	public void onLeave(PlayerLeaveTeamEvent e) {
+	public void onLeave(PostPlayerLeaveTeamEvent e) {
 		List<TeamPlayer> players = e.getTeam().getRank(PlayerRank.OWNER);
 
 		for (TeamPlayer player : players) {
@@ -99,7 +98,6 @@ public class UltimateClaimsManager implements Listener {
 			ClaimMember member = c.getMember(e.getPlayer());
 			c.removeMember(member);
 			JavaPlugin.getPlugin(UltimateClaims.class).getDataHelper().deleteMember(member);
-
 		}
 	}
 
@@ -153,28 +151,29 @@ public class UltimateClaimsManager implements Listener {
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-	public void disbandEvent(DisbandTeamEvent event) {
+	public void disbandEvent(PostDisbandTeamEvent event) {
+		for (TeamPlayer player : event.getMembers()) {
+			if (player.getRank() != PlayerRank.OWNER) {
+				continue;
+			}
 
-		for (TeamPlayer player : event.getTeam().getRank(PlayerRank.OWNER)) {
 			Claim c = JavaPlugin.getPlugin(UltimateClaims.class).getClaimManager().getClaim(player.getPlayer().getUniqueId());
 			if (c == null) {
 				continue;
 			}
 
 			new BukkitRunnable() {
-				
+
 				@Override
 				public void run() {
 					c.destroy(ClaimDeleteReason.PLAYER);
 				}
 			}.runTask(Main.plugin);
-			
+
 
 			if (player.getPlayer().isOnline()) {
 				MessageManager.sendMessage(player.getPlayer().getPlayer(), "uclaim.dissolve");
 			}
 		}
-
 	}
-
 }

--- a/src/main/java/com/booksaw/betterTeams/score/ScoreManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/score/ScoreManagement.java
@@ -2,7 +2,7 @@ package com.booksaw.betterTeams.score;
 
 import com.booksaw.betterTeams.Main;
 import com.booksaw.betterTeams.Team;
-import com.booksaw.betterTeams.customEvents.PrePurgeEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPurgeEvent;
 import com.booksaw.betterTeams.score.ScoreChange.ChangeType;
 import me.clip.placeholderapi.PlaceholderAPI;
 import org.bukkit.Bukkit;
@@ -84,7 +84,7 @@ public class ScoreManagement implements Listener {
 	}
 
 	@EventHandler
-	public void onPurge(PrePurgeEvent e) {
+	public void onPurge(PostPurgeEvent e) {
 		Bukkit.getScheduler().runTask(Main.plugin, () -> {
 			Main.plugin.getConfig().getStringList("purgeCommands").forEach(cmd -> {
 				if (Main.plugin.getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")) {
@@ -92,7 +92,6 @@ public class ScoreManagement implements Listener {
 				}
 
 				Bukkit.dispatchCommand(Bukkit.getConsoleSender(), cmd);
-
 			});
 		});
 	}

--- a/src/main/java/com/booksaw/betterTeams/team/MemberSetComponent.java
+++ b/src/main/java/com/booksaw/betterTeams/team/MemberSetComponent.java
@@ -5,6 +5,8 @@ import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.TeamPlayer;
 import com.booksaw.betterTeams.customEvents.PlayerJoinTeamEvent;
 import com.booksaw.betterTeams.customEvents.PlayerLeaveTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPlayerJoinTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPlayerLeaveTeamEvent;
 import com.booksaw.betterTeams.exceptions.CancelledEventException;
 import com.booksaw.betterTeams.message.Message;
 import com.booksaw.betterTeams.message.MessageManager;
@@ -48,12 +50,7 @@ public class MemberSetComponent extends TeamPlayerSetComponent {
 		Team.getTeamManager().playerJoinTeam(team, teamPlayer);
 		set.add(teamPlayer);
 
-		if (Main.plugin.getConfig().getBoolean("announceTeamJoin")) {
-			Message message = new ReferencedFormatMessage("announce.join", p.getName(), team.getColor() + team.getName() + ChatColor.RESET);
-			for (Player player : Bukkit.getOnlinePlayers()) {
-				message.sendMessage(player);
-			}
-		}
+		Bukkit.getPluginManager().callEvent(new PostPlayerJoinTeamEvent(team, teamPlayer));
 	}
 
 	@Override
@@ -73,12 +70,7 @@ public class MemberSetComponent extends TeamPlayerSetComponent {
 		Team.getTeamManager().playerLeaveTeam(team, teamPlayer);
 		set.remove(teamPlayer);
 
-		if (Main.plugin.getConfig().getBoolean("announceTeamLeave")) {
-			Message message = new ReferencedFormatMessage("announce.leave", p.getName(), team.getColor() + team.getName() + ChatColor.RESET);
-			for (Player player : Bukkit.getOnlinePlayers()) {
-				message.sendMessage(player);
-			}
-		}
+		Bukkit.getPluginManager().callEvent(new PostPlayerLeaveTeamEvent(team, teamPlayer));
 	}
 
 	@Override

--- a/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
@@ -5,6 +5,8 @@ import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.TeamPlayer;
 import com.booksaw.betterTeams.customEvents.CreateTeamEvent;
 import com.booksaw.betterTeams.customEvents.PrePurgeEvent;
+import com.booksaw.betterTeams.customEvents.post.PostCreateTeamEvent;
+import com.booksaw.betterTeams.customEvents.post.PostPurgeEvent;
 import com.booksaw.betterTeams.events.ChestManagement;
 import com.booksaw.betterTeams.team.storage.team.TeamStorage;
 import org.bukkit.Bukkit;
@@ -183,6 +185,8 @@ public abstract class TeamManager {
 			Main.plugin.teamManagement.displayBelowName(owner);
 		}
 
+		Bukkit.getPluginManager().callEvent(new PostCreateTeamEvent(team, owner));
+
 		return team;
 	}
 
@@ -336,6 +340,7 @@ public abstract class TeamManager {
 			purgeTeamMoney();
 		}
 
+		Bukkit.getPluginManager().callEvent(new PostPurgeEvent());
 		return true;
 	}
 


### PR DESCRIPTION
This PR adds a complete set of post-events that fire after team-related actions are completed. These events allow other plugins to react to team changes after they occur, complementing the existing pre-events that handle cancellation and modification.

Added post-events for:
- Team creation/disbanding
- Player join/leave
- Player rank changes (promote/demote)
- Team settings changes (name, tag, color)
- Team economy (deposits/withdrawals)
- Team leveling
- Team purge completion

Additional changes:
- Refactored UltimateClaimsManager to use post-events instead of pre-events, ensuring actions are only processed after they're guaranteed to complete
- Reduced code duplication by introducing a registerTeam() method in Team class, consolidating 3 duplicate implementations
- Improved code organization by moving message handling logic into dedicated event handlers

All post-events follow consistent patterns:
- Cannot be cancelled (as they fire after the action)
- Include references to their corresponding pre-events
- Carry relevant data about the completed action

This provides a robust event system where plugins can both prevent actions (pre-events) and react to completed actions (post-events).