### PR TITLE
refactor: Convert TeamPlayerSetComponent to use streaming API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
     </dependencies>
     <build>
         <finalName>BetterTeams-${project.version}</finalName>
-        <sourceDirectory>src</sourceDirectory>
+        <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/booksaw/betterTeams/TeamPlayer.java
+++ b/src/main/java/com/booksaw/betterTeams/TeamPlayer.java
@@ -149,4 +149,12 @@ public class TeamPlayer {
 		this.title = title;
 	}
 
+	/**
+	 * Checks if the player associated with this TeamPlayer is currently online.
+	 *
+	 * @return true if the player is online, false otherwise
+	 */
+	public boolean isOnline() {
+		return getPlayer().isOnline();
+	}
 }

--- a/src/main/java/com/booksaw/betterTeams/Utils.java
+++ b/src/main/java/com/booksaw/betterTeams/Utils.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.List;
@@ -26,7 +27,7 @@ public class Utils {
 	 * @param name The name of the player
 	 * @return The offlinePlayer object
 	 */
-	public static OfflinePlayer getOfflinePlayer(String name) {
+	public static @Nullable OfflinePlayer getOfflinePlayer(String name) {
 
 		@SuppressWarnings("deprecation")
 		OfflinePlayer player = Bukkit.getOfflinePlayer(name);

--- a/src/main/java/com/booksaw/betterTeams/team/TeamPlayerSetComponent.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamPlayerSetComponent.java
@@ -38,7 +38,6 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	 * @return A list of all teamPlayers which are currently online
 	 */
 	public List<TeamPlayer> getOnlineTeamPlayers() {
-		// Get all team players, filter for those who are online
 		return getClone().stream()
 			.filter(TeamPlayer::isOnline)
 			.collect(Collectors.toList());
@@ -52,7 +51,6 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	 */
 	@Nullable
 	public TeamPlayer getTeamPlayer(@NotNull OfflinePlayer p) {
-		// Find the first team player whose UUID matches the given player
 		return getClone().stream()
 			.filter(teamPlayer -> p.getUniqueId().equals(teamPlayer.getPlayer().getUniqueId()))
 			.findFirst()
@@ -111,7 +109,6 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	 * @return true if the player is in this team, false otherwise
 	 */
 	public boolean contains(OfflinePlayer player) {
-		// Check if any team player has the same UUID as the given player
 		return getClone().stream()
 			.map(TeamPlayer::getPlayer)
 			.map(OfflinePlayer::getUniqueId)
@@ -122,7 +119,6 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	 * @return A comma-separated string of all online player names
 	 */
 	public String getOnlinePlayersString() {
-		// Create a comma-separated list of player names
 		return getOnlinePlayers().stream()
 			.map(Player::getName)
 			.collect(Collectors.joining(", "));
@@ -132,7 +128,6 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	 * @return A comma-separated string of all offline player names
 	 */
 	public String getOfflinePlayersString() {
-		// Create a comma-separated list of player names
 		return getOfflinePlayers().stream()
 			.map(OfflinePlayer::getName)
 			.collect(Collectors.joining(", "));

--- a/src/main/java/com/booksaw/betterTeams/team/TeamPlayerSetComponent.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamPlayerSetComponent.java
@@ -30,7 +30,7 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	public List<OfflinePlayer> getOfflinePlayers() {
 		return getClone().stream()
 			.map(TeamPlayer::getPlayer)
-			.filter(OfflinePlayer::isOnline)
+			.filter(p -> !p.isOnline())
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/com/booksaw/betterTeams/team/TeamPlayerSetComponent.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamPlayerSetComponent.java
@@ -8,8 +8,8 @@ import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer> {
 
@@ -17,84 +17,67 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	 * @return A list of players which are currently online and on this team
 	 */
 	public List<Player> getOnlinePlayers() {
-		List<Player> online = new ArrayList<>();
-
-		for (TeamPlayer player : getClone()) {
-			if (player.getPlayer().isOnline()) {
-				online.add(player.getPlayer().getPlayer());
-			}
-		}
-
-		return online;
+		return getClone().stream()
+			.map(TeamPlayer::getPlayer)
+			.filter(OfflinePlayer::isOnline)
+			.map(OfflinePlayer::getPlayer)
+			.collect(Collectors.toList());
 	}
 
 	/**
 	 * @return A list of players which are currently online on this team
 	 */
 	public List<OfflinePlayer> getOfflinePlayers() {
-		List<OfflinePlayer> offline = new ArrayList<>();
-
-		for (TeamPlayer player : getClone()) {
-			if (!player.getPlayer().isOnline()) {
-				offline.add(player.getPlayer());
-			}
-		}
-
-		return offline;
+		return getClone().stream()
+			.map(TeamPlayer::getPlayer)
+			.filter(OfflinePlayer::isOnline)
+			.collect(Collectors.toList());
 	}
 
 	/**
 	 * @return A list of all teamPlayers which are currently online
 	 */
 	public List<TeamPlayer> getOnlineTeamPlayers() {
-		List<TeamPlayer> online = new ArrayList<>();
-
-		for (TeamPlayer player : getClone()) {
-			if (player.getPlayer().isOnline()) {
-				online.add(player);
-			}
-		}
-
-		return online;
+		// Get all team players, filter for those who are online
+		return getClone().stream()
+			.filter(TeamPlayer::isOnline)
+			.collect(Collectors.toList());
 	}
 
 	/**
 	 * Used to get the team player instance of that offline player
-	 * 
+	 *
 	 * @param p The player to get the team player for
-	 * @return The team player instance
+	 * @return The team player instance, or null if not found
 	 */
 	@Nullable
 	public TeamPlayer getTeamPlayer(@NotNull OfflinePlayer p) {
-		for (TeamPlayer player : getClone()) {
-			if (p.getUniqueId().equals(player.getPlayer().getUniqueId())) {
-				return player;
-			}
-		}
-		return null;
+		// Find the first team player whose UUID matches the given player
+		return getClone().stream()
+			.filter(teamPlayer -> p.getUniqueId().equals(teamPlayer.getPlayer().getUniqueId()))
+			.findFirst()
+			.orElse(null);
 	}
 
+	/**
+	 * Get all team players with the specified rank
+	 *
+	 * @param rank The rank to filter by
+	 * @return List of team players with the specified rank
+	 */
 	public List<TeamPlayer> getRank(PlayerRank rank) {
-		List<TeamPlayer> toReturn = new ArrayList<>();
-
-		for (TeamPlayer player : getClone()) {
-			if (player.getRank() == rank) {
-				toReturn.add(player);
-			}
-		}
-
-		return toReturn;
+		return getClone().stream()
+			.filter(player -> player.getRank() == rank)
+			.collect(Collectors.toList());
 	}
 
 	/**
 	 * Sends the specified message to all team players stored in the list
-	 * 
+	 *
 	 * @param message The message to send to all online players
 	 */
 	public void broadcastMessage(Message message) {
-		for (Player p : getOnlinePlayers()) {
-			message.sendMessage(p);
-		}
+		getOnlinePlayers().forEach(message::sendMessage);
 	}
 
 	/**
@@ -103,9 +86,7 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	 * @param message The message to send to all online players
 	 */
 	public void broadcastTitle(Message message) {
-		for (Player p : getOnlinePlayers()) {
-			message.sendTitle(p);
-		}
+		getOnlinePlayers().forEach(message::sendTitle);
 	}
 
 	@Override
@@ -123,54 +104,37 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 		return contains(component.getPlayer());
 	}
 
+	/**
+	 * Checks if the given player is in this team
+	 *
+	 * @param player The player to check for
+	 * @return true if the player is in this team, false otherwise
+	 */
 	public boolean contains(OfflinePlayer player) {
-
-		for (TeamPlayer tp : getClone()) {
-			if (tp.getPlayer().getUniqueId().equals(player.getUniqueId())) {
-				return true;
-			}
-		}
-		return false;
+		// Check if any team player has the same UUID as the given player
+		return getClone().stream()
+			.map(TeamPlayer::getPlayer)
+			.map(OfflinePlayer::getUniqueId)
+			.anyMatch(uuid -> uuid.equals(player.getUniqueId()));
 	}
 
 	/**
-	 * @return the string of all online players
+	 * @return A comma-separated string of all online player names
 	 */
 	public String getOnlinePlayersString() {
-
-		String str = "";
-
-		List<Player> onlinePlayers = getOnlinePlayers();
-
-		if (onlinePlayers.isEmpty()) {
-			return "";
-		}
-
-		for (Player player : onlinePlayers) {
-			str = str + player.getName() + ", ";
-		}
-
-		str = str.substring(0, str.length() - 2);
-
-		return str;
+		// Create a comma-separated list of player names
+		return getOnlinePlayers().stream()
+			.map(Player::getName)
+			.collect(Collectors.joining(", "));
 	}
 
+	/**
+	 * @return A comma-separated string of all offline player names
+	 */
 	public String getOfflinePlayersString() {
-		String str = "";
-
-		List<OfflinePlayer> offlinePlayers = getOfflinePlayers();
-
-		if (offlinePlayers.isEmpty()) {
-			return "";
-		}
-
-		for (OfflinePlayer player : offlinePlayers) {
-			str = str + player.getName() + ", ";
-		}
-
-		str = str.substring(0, str.length() - 2);
-
-		return str;
+		// Create a comma-separated list of player names
+		return getOfflinePlayers().stream()
+			.map(OfflinePlayer::getName)
+			.collect(Collectors.joining(", "));
 	}
-
 }

--- a/src/main/java/com/booksaw/betterTeams/team/TeamPlayerSetComponent.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamPlayerSetComponent.java
@@ -109,10 +109,7 @@ public abstract class TeamPlayerSetComponent extends SetTeamComponent<TeamPlayer
 	 * @return true if the player is in this team, false otherwise
 	 */
 	public boolean contains(OfflinePlayer player) {
-		return getClone().stream()
-			.map(TeamPlayer::getPlayer)
-			.map(OfflinePlayer::getUniqueId)
-			.anyMatch(uuid -> uuid.equals(player.getUniqueId()));
+		return getTeamPlayer(player) != null;
 	}
 
 	/**


### PR DESCRIPTION
This PR refactors the TeamPlayerSetComponent class to use Java 8 streaming interfaces instead of traditional for-loops.

Key changes:
- Replace all for-loops with stream operations
- Used method references where appropriate
- Added comments
