### PR TITLE
build: Fix Maven build warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,12 @@
     <name>BetterTeams</name>
     <packaging>jar</packaging>
     <description>Create teams to fight to be the best</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <repositories>
         <repository>
             <id>spigot-repo</id>
@@ -137,7 +143,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.0</version>
                 <configuration>
-                    <encoding>UTF-8</encoding>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,15 @@
                             <shadedPattern>booksawshaded.com.github.benmanes.caffeine</shadedPattern>
                         </relocation>
                     </relocations>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*</exclude>
+                                <exclude>META-INF/versions/**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This PR addresses Maven build warnings with minimal changes:

1. Fixed platform-dependent encoding warnings by adding project-wide encoding properties
2. Simplified Maven Shade Plugin configuration by excluding all META-INF files to prevent resource overlap warnings

These changes result in a cleaner build process without affecting the plugin's functionality.