### PR TITLE
perf: Several performance improvements

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/ConfigManager.java
+++ b/src/main/java/com/booksaw/betterTeams/ConfigManager.java
@@ -6,6 +6,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -203,7 +204,7 @@ public class ConfigManager {
 					"The embedded resource '" + resourcePath + "' cannot be found in " + Main.plugin.getDataFolder());
 		File outFile = new File(resultPath);
 		int lastIndex = resourcePath.lastIndexOf('/');
-		File outDir = new File(resultPath.substring(0, (lastIndex >= 0) ? lastIndex : 0));
+		File outDir = new File(resultPath.substring(0, Math.max(lastIndex, 0)));
 
 		if (!outDir.exists())
 			outDir.mkdirs();
@@ -214,7 +215,7 @@ public class ConfigManager {
 					outFile.createNewFile();
 				}
 
-				OutputStream out = new FileOutputStream(outFile);
+				OutputStream out = Files.newOutputStream(outFile.toPath());
 				byte[] buf = new byte[1024];
 				int len;
 				while ((len = in.read(buf)) > 0)

--- a/src/main/java/com/booksaw/betterTeams/commands/team/InfoCommand.java
+++ b/src/main/java/com/booksaw/betterTeams/commands/team/InfoCommand.java
@@ -101,9 +101,7 @@ public class InfoCommand extends SubCommand {
 				}
 			}
 			for (TeamPlayer player : users) {
-				userStr.append(
-						MessageManager.getMessage("info." + ((player.getPlayer().isOnline() && player.getOnlinePlayer().map(p -> !Utils.isVanished(p)).orElse(false)) ? "online" : "offline"))
-								+ player.getPrefix(returnTo))
+				userStr.append(MessageManager.getMessage("info." + ((player.getPlayer().isOnline() && player.getOnlinePlayer().map(p -> !Utils.isVanished(p)).orElse(false)) ? "online" : "offline"))).append(player.getPrefix(returnTo))
 						.append(player.getPlayer().getName()).append(" ");
 			}
 

--- a/src/main/java/com/booksaw/betterTeams/database/api/TableBuilder.java
+++ b/src/main/java/com/booksaw/betterTeams/database/api/TableBuilder.java
@@ -54,7 +54,7 @@ public class TableBuilder {
 					"The data type " + type + " needs an argument, and no argument was provided");
 		}
 
-		tableInfo.append(columnName + " " + type + ((notNull) ? " NOT NULL, " : ", "));
+		tableInfo.append(columnName).append(" ").append(type).append((notNull) ? " NOT NULL, " : ", ");
 		return this;
 	}
 
@@ -68,8 +68,7 @@ public class TableBuilder {
 					"The data type " + type + " needs an argument, and no argument was provided");
 		}
 
-		tableInfo
-				.append(columnName + " " + type + "(" + argument + ")" + ((notNull) ? " NOT NULL, " : ", "));
+		tableInfo.append(columnName).append(" ").append(type).append("(").append(argument).append(")").append((notNull) ? " NOT NULL, " : ", ");
 		return this;
 	}
 

--- a/src/main/java/com/booksaw/betterTeams/team/storage/convert/FlatFileToYaml.java
+++ b/src/main/java/com/booksaw/betterTeams/team/storage/convert/FlatFileToYaml.java
@@ -10,6 +10,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.*;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -35,8 +36,8 @@ public class FlatFileToYaml extends Converter {
 			}
 		}
 
-		try (InputStream in = new BufferedInputStream(new FileInputStream(f));
-				OutputStream out = new BufferedOutputStream(new FileOutputStream(copied))) {
+		try (InputStream in = new BufferedInputStream(Files.newInputStream(f.toPath()));
+		     OutputStream out = new BufferedOutputStream(Files.newOutputStream(copied.toPath()))) {
 
 			byte[] buffer = new byte[1024];
 			int lengthRead;

--- a/src/main/java/com/booksaw/betterTeams/team/storage/storageManager/SQLStorageManager.java
+++ b/src/main/java/com/booksaw/betterTeams/team/storage/storageManager/SQLStorageManager.java
@@ -235,7 +235,7 @@ public class SQLStorageManager extends TeamManager implements Listener {
 				toReturn.add(results.getString("name"));
 			}
 			ps.close();
-			return toReturn.toArray(new String[toReturn.size()]);
+			return toReturn.toArray(new String[0]);
 
 		} catch (Exception e) {
 			Bukkit.getLogger().severe("Could not sort teams for results, report the following error:");


### PR DESCRIPTION
StringBuilder - chain append calls instead of concatenation
Stream - use Files.newInputStream/newOutputStream instead of the FileInputStream
Array creation - don't create a big array if all it needs is the type

__Background info:__
Here's why the `Files` methods (second snippet) tend to perform better:

1. **Operating System Optimizations**: The NIO-based `Files` methods can take advantage of operating system-specific optimizations. They're designed to use native I/O operations where possible.

2. **Memory-Mapped Files**: The NIO package can potentially use memory-mapped files internally, which provides faster access by mapping a file directly to memory.

3. **Channel-Based Operations**: Behind the scenes, `Files` methods use `FileChannel` which can perform more efficient block transfers between files.

4. **Direct Buffer Access**: NIO can use direct buffers that aren't subject to garbage collection and can interact more efficiently with native I/O operations.

5. **Non-Blocking I/O**: While both examples are using blocking I/O in this case, the underlying NIO infrastructure is designed for more efficient I/O handling.

The performance difference might be more noticeable with larger files or in high-throughput scenarios. For small files or infrequent operations, the difference may be negligible.