### PR TITLE
minimize the final jar -- keep only what's necessary.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
                 <configuration>
+                    <minimizeJar>true</minimizeJar>
                     <relocations>
                         <relocation>
                             <pattern>com.github.benmanes.caffeine</pattern>


### PR DESCRIPTION
This reduces the file size from 1.7MB to 962k (together with the lombok-PR).

I verified that all betterteams sources are present. It looks like it's mainly reducing caffeine from a 2.2M include to a 753k include (non-packed)

What you need to watch out for when minimizing is reflection things. Because then the maven shade plugin will not know it's being used.
I don't see anything in betterteams that use reflection (except the command map, but that's server-related, not shaded)...