### PR TITLE
Adding 'database.tablePrefix' to config and using it in TableName class

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/database/TableName.java
+++ b/src/main/java/com/booksaw/betterTeams/database/TableName.java
@@ -1,5 +1,7 @@
 package com.booksaw.betterTeams.database;
 
+import com.booksaw.betterTeams.Main;
+
 public enum TableName {
 	TEAM("Team"), PLAYERS("Players"), ALLYREQUESTS("AllyRequests"), WARPS("warps"), CHESTCLAIMS("ChestClaims"),
 	BANS("Bans"), ALLIES("Allies");
@@ -12,7 +14,7 @@ public enum TableName {
 
 	@Override
 	public String toString() {
-		return "BetterTeams_" + tableName;
+		return Main.plugin.getConfig().getString("database.tablePrefix") + tableName;
 	}
 
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -58,6 +58,7 @@ database:
   database: spigot
   user: root
   password: password
+  tablePrefix: BetterTeams_
 
 # This is the value to determine if the chat prefix is enabled
 # - If this is enabled (true / name) a prefix [TeamName] will be displayed at the begining of chat messages.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -58,6 +58,13 @@ database:
   database: spigot
   user: root
   password: password
+  # Prefix for SQL tables.
+  # After changing this String and reloading the plugin/server,
+  # BetterTeams will start using it as the new Table Prefix when storing and reading team data.
+  # Only recommended changing when setting up your server,
+  # otherwise all team data stored under the last prefix will stop being used until you change it back (if previous tables remain intact).
+  # Thought for network servers that use the same database but are not supposed to share same team data.
+  # Default value is "BetterTeams_" as it has always been, to prevent sudden change if you have been using SQL.
   tablePrefix: BetterTeams_
 
 # This is the value to determine if the chat prefix is enabled


### PR DESCRIPTION
I think a configurable table prefix is ​​a good addition for that niche where you may have only one database but use it on multiple servers in a network.