### PR TITLE
Optimize onHopper event for Paper users

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>placeholderapi</id>
@@ -40,8 +40,8 @@
     </repositories>
     <dependencies>
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
@@ -111,6 +111,12 @@
             <version>3.0.2</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>io.papermc</groupId>
+            <artifactId>paperlib</artifactId>
+            <version>1.0.8</version>
+            <scope>compile</scope>
+        </dependency>
 
         <!-- JUnit 5 -->
         <dependency>
@@ -150,6 +156,10 @@
                         <relocation>
                             <pattern>org.bstats</pattern>
                             <shadedPattern>booksawshaded.com.org.bstats</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>io.papermc.lib</pattern>
+                            <shadedPattern>booksawshaded.com.org.paperlib</shadedPattern>
                         </relocation>
                     </relocations>
                     <filters>

--- a/src/main/java/com/booksaw/betterTeams/events/ChestManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/ChestManagement.java
@@ -2,10 +2,12 @@ package com.booksaw.betterTeams.events;
 
 import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.message.MessageManager;
+import com.booksaw.betterTeams.util.Adapter;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
+import org.bukkit.block.DoubleChest;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -13,6 +15,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 
@@ -58,7 +61,9 @@ public class ChestManagement implements Listener {
 
 	@EventHandler
 	public void onHopper(InventoryMoveItemEvent e) {
-		Team claimedBy = Team.getClaimingTeam(e.getSource().getHolder());
+		if (e.getSource().getType() != InventoryType.CHEST) return;
+
+		Team claimedBy = Team.getClaimingTeam(Adapter.getInventoryHolder(e.getSource(), false));
 
 		if (claimedBy != null) {
 			e.setCancelled(true);

--- a/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
@@ -10,11 +10,13 @@ import com.booksaw.betterTeams.customEvents.post.PostCreateTeamEvent;
 import com.booksaw.betterTeams.customEvents.post.PostPurgeEvent;
 import com.booksaw.betterTeams.events.ChestManagement;
 import com.booksaw.betterTeams.team.storage.team.TeamStorage;
+import com.booksaw.betterTeams.util.Adapter;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
 import org.bukkit.block.Chest;
 import org.bukkit.block.DoubleChest;
 import org.bukkit.entity.Player;
@@ -234,13 +236,14 @@ public abstract class TeamManager {
 	 */
 	public Team getClaimingTeam(Block block) {
 		// player is opening a chest
-		if (block.getState() instanceof Chest) {
-			Chest chest = (Chest) block.getState();
-			InventoryHolder holder = chest.getInventory().getHolder();
+		BlockState state = Adapter.getState(block, false);
+		if (state instanceof Chest) {
+			Chest chest = (Chest) state;
+			InventoryHolder holder = Adapter.getInventoryHolder(chest.getInventory(), false);
 			return getClaimingTeam(holder);
-		} else if (block.getState() instanceof DoubleChest) {
-			DoubleChest chest = (DoubleChest) block.getState();
-			InventoryHolder holder = chest.getInventory().getHolder();
+		} else if (state instanceof DoubleChest) {
+			DoubleChest chest = (DoubleChest) state;
+			InventoryHolder holder = Adapter.getInventoryHolder(chest.getInventory(), false);
 			return getClaimingTeam(holder);
 		}
 
@@ -260,12 +263,12 @@ public abstract class TeamManager {
 
 		if (holder instanceof DoubleChest) {
 			DoubleChest doubleChest = (DoubleChest) holder;
-			Team claimedBy = getClaimingTeam(ChestManagement.getLocation((Chest) doubleChest.getLeftSide()));
+			Team claimedBy = getClaimingTeam(ChestManagement.getLocation((Chest) Adapter.getLeftSide(doubleChest, false)));
 			if (claimedBy != null) {
 				return claimedBy;
 			}
 
-			return getClaimingTeam(ChestManagement.getLocation((Chest) doubleChest.getRightSide()));
+			return getClaimingTeam(ChestManagement.getLocation((Chest) Adapter.getRightSide(doubleChest, false)));
 		} else if (holder instanceof Chest) {
 			// single chest
 			return getClaimingTeam(ChestManagement.getLocation((Chest) holder));
@@ -283,19 +286,19 @@ public abstract class TeamManager {
 	 */
 	public Location getClaimingLocation(Block block) {
 		// player is opening a chest
-		Chest chest = (Chest) block.getState();
-		InventoryHolder holder = chest.getInventory().getHolder();
+		Chest chest = (Chest) Adapter.getState(block, false);
+		InventoryHolder holder = Adapter.getInventoryHolder(chest.getInventory(), false);
 
 		if (holder instanceof DoubleChest) {
 			DoubleChest doubleChest = (DoubleChest) holder;
-			Location loc = ChestManagement.getLocation((Chest) doubleChest.getLeftSide());
+			Location loc = ChestManagement.getLocation((Chest) Adapter.getLeftSide(doubleChest, false));
 			Team claimedBy = getClaimingTeam(loc);
 			if (claimedBy != null) {
 				return loc;
 			}
 
-			loc = ChestManagement.getLocation((Chest) doubleChest.getRightSide());
-			claimedBy = getClaimingTeam(ChestManagement.getLocation((Chest) doubleChest.getRightSide()));
+			loc = ChestManagement.getLocation((Chest) Adapter.getRightSide(doubleChest, false));
+			claimedBy = getClaimingTeam(loc);
 			if (claimedBy != null) {
 				return loc;
 			}

--- a/src/main/java/com/booksaw/betterTeams/util/Adapter.java
+++ b/src/main/java/com/booksaw/betterTeams/util/Adapter.java
@@ -1,0 +1,34 @@
+package com.booksaw.betterTeams.util;
+
+import io.papermc.lib.PaperLib;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.DoubleChest;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+
+public class Adapter {
+	private static final boolean isHolderSupported = PaperLib.isPaper() && PaperLib.getEnvironment().isVersion(16);
+
+	public static InventoryHolder getInventoryHolder(Inventory inventory, boolean snapshots) {
+		return PaperLib.getHolder(inventory, snapshots).getHolder();
+	}
+
+	public static InventoryHolder getLeftSide(DoubleChest chest, boolean snapshots) {
+		if (isHolderSupported) {
+			return chest.getLeftSide(false);
+		}
+		return chest.getLeftSide();
+	}
+
+	public static InventoryHolder getRightSide(DoubleChest chest, boolean snapshots) {
+		if (isHolderSupported) {
+			return chest.getRightSide(false);
+		}
+		return chest.getRightSide();
+	}
+
+	public static BlockState getState(Block block, boolean snapshots) {
+		return PaperLib.getBlockState(block, snapshots).getState();
+	}
+}


### PR DESCRIPTION
Compiled against Paper and used PaperLib to maintain compatibility while improving performance.

Spark before: https://spark.lucko.me/d26dJrbWom

After: https://spark.lucko.me/eVZn1JX9Nc

Small note for Spigot users: I added a small condition that skips all the next checks if the source is not a Chest, but unfortunatly overall this doesn't affect Spigot users.