### PR TITLE
Optimize onHopper for both Spigot and Paper users

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/Team.java
+++ b/src/main/java/com/booksaw/betterTeams/Team.java
@@ -18,7 +18,6 @@ import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scoreboard.Scoreboard;
 import org.jetbrains.annotations.Contract;
@@ -85,10 +84,6 @@ public class Team {
 
 	public static Team getClaimingTeam(Block block) {
 		return TEAMMANAGER.getClaimingTeam(block);
-	}
-
-	public static Team getClaimingTeam(InventoryHolder holder) {
-		return TEAMMANAGER.getClaimingTeam(holder);
 	}
 
 	public static Team getClaimingTeam(Location location) {

--- a/src/main/java/com/booksaw/betterTeams/events/ChestManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/ChestManagement.java
@@ -5,6 +5,7 @@ import com.booksaw.betterTeams.message.MessageManager;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.Chest;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -13,6 +14,7 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 
@@ -24,6 +26,56 @@ public class ChestManagement implements Listener {
 
 	public static Location getLocation(Chest chest) {
 		return new Location(chest.getWorld(), chest.getX(), chest.getY(), chest.getZ());
+	}
+
+	/**
+	 * Used to get the other side of a DoubleChest
+	 *
+	 * @param block A Chest (either DoubleChest or Single)
+	 * @return The other side Location
+	 */
+	public static Location getOtherSide(Block block) {
+		if (block.getType() != Material.CHEST) return null; // Just in case, should be a light check
+
+		org.bukkit.block.data.type.Chest chest = (org.bukkit.block.data.type.Chest) block.getBlockData();
+
+		if (chest.getType() == org.bukkit.block.data.type.Chest.Type.SINGLE) return block.getLocation();
+
+		if (chest.getType() == org.bukkit.block.data.type.Chest.Type.LEFT) {
+			switch (chest.getFacing()) {
+				case NORTH:
+					return block.getRelative(BlockFace.EAST).getLocation();
+				case EAST:
+					return block.getRelative(BlockFace.SOUTH).getLocation();
+				case SOUTH:
+					return block.getRelative(BlockFace.WEST).getLocation();
+				case WEST:
+					return block.getRelative(BlockFace.NORTH).getLocation();
+			}
+		} else {
+			switch (chest.getFacing()) {
+				case NORTH:
+					return block.getRelative(BlockFace.WEST).getLocation();
+				case EAST:
+					return block.getRelative(BlockFace.NORTH).getLocation();
+				case SOUTH:
+					return block.getRelative(BlockFace.EAST).getLocation();
+				case WEST:
+					return block.getRelative(BlockFace.SOUTH).getLocation();
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Used to check the two locations after they were passed to getOtherSide
+	 *
+	 * @param l1 One of the two sides
+	 * @param l2 One of the two sides
+	 * @return
+	 */
+	public static boolean isSingleChest(Location l1, Location l2) {
+		return l1.equals(l2);
 	}
 
 	@EventHandler
@@ -58,7 +110,9 @@ public class ChestManagement implements Listener {
 
 	@EventHandler
 	public void onHopper(InventoryMoveItemEvent e) {
-		Team claimedBy = Team.getClaimingTeam(e.getSource().getHolder());
+		if (e.getSource().getType() != InventoryType.CHEST) return;
+
+		Team claimedBy = Team.getClaimingTeam(e.getSource().getLocation().getBlock());
 
 		if (claimedBy != null) {
 			e.setCancelled(true);

--- a/src/main/java/com/booksaw/betterTeams/events/ChestManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/ChestManagement.java
@@ -112,7 +112,10 @@ public class ChestManagement implements Listener {
 	public void onHopper(InventoryMoveItemEvent e) {
 		if (e.getSource().getType() != InventoryType.CHEST) return;
 
-		Team claimedBy = Team.getClaimingTeam(e.getSource().getLocation().getBlock());
+		Location location = e.getSource().getLocation();
+		if (location == null) return;
+
+		Team claimedBy = Team.getClaimingTeam(location.getBlock());
 
 		if (claimedBy != null) {
 			e.setCancelled(true);

--- a/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
@@ -267,15 +267,14 @@ public abstract class TeamManager {
 		if (ChestManagement.isSingleChest(location1, location2)) {
 			Team claimedBy = getClaimingTeam(location1);
 			if (claimedBy != null) return location1;
-			return null;
 		} else {
 			Team claimedBy = getClaimingTeam(location1);
 			if (claimedBy != null) return location1;
 
 			claimedBy = getClaimingTeam(location2);
 			if (claimedBy != null) return location2;
-			return null;
 		}
+		return null;
 	}
 
 	/**

--- a/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
+++ b/src/main/java/com/booksaw/betterTeams/team/TeamManager.java
@@ -13,6 +13,7 @@ import com.booksaw.betterTeams.team.storage.team.TeamStorage;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
 import org.bukkit.block.Chest;
@@ -234,44 +235,19 @@ public abstract class TeamManager {
 	 */
 	public Team getClaimingTeam(Block block) {
 		// player is opening a chest
-		if (block.getState() instanceof Chest) {
-			Chest chest = (Chest) block.getState();
-			InventoryHolder holder = chest.getInventory().getHolder();
-			return getClaimingTeam(holder);
-		} else if (block.getState() instanceof DoubleChest) {
-			DoubleChest chest = (DoubleChest) block.getState();
-			InventoryHolder holder = chest.getInventory().getHolder();
-			return getClaimingTeam(holder);
+		if (block.getType() != Material.CHEST) return null; // Just in case, should be a light check
+
+		Location location1 = block.getLocation();
+		Location location2 = ChestManagement.getOtherSide(block);
+
+		if (ChestManagement.isSingleChest(location1, location2)) {
+			return getClaimingTeam(location1);
 		}
 
-		return null;
+		Team claimedBy = getClaimingTeam(location1);
+		if (claimedBy != null) return claimedBy;
 
-	}
-
-	/**
-	 * Used to get the claiming team of a chest, will check both parts of a double
-	 * chest, it is assumed that the provided block is known to be a chest
-	 *
-	 * @param holder the inventory holder of the block to check
-	 * @return The team which has claimed that block
-	 */
-	public Team getClaimingTeam(InventoryHolder holder) {
-		// player is opening a chest
-
-		if (holder instanceof DoubleChest) {
-			DoubleChest doubleChest = (DoubleChest) holder;
-			Team claimedBy = getClaimingTeam(ChestManagement.getLocation((Chest) doubleChest.getLeftSide()));
-			if (claimedBy != null) {
-				return claimedBy;
-			}
-
-			return getClaimingTeam(ChestManagement.getLocation((Chest) doubleChest.getRightSide()));
-		} else if (holder instanceof Chest) {
-			// single chest
-			return getClaimingTeam(ChestManagement.getLocation((Chest) holder));
-		}
-
-		return null;
+		return getClaimingTeam(location2);
 	}
 
 	/**
@@ -283,31 +259,23 @@ public abstract class TeamManager {
 	 */
 	public Location getClaimingLocation(Block block) {
 		// player is opening a chest
-		Chest chest = (Chest) block.getState();
-		InventoryHolder holder = chest.getInventory().getHolder();
+		if (block.getType() != Material.CHEST) return null;
 
-		if (holder instanceof DoubleChest) {
-			DoubleChest doubleChest = (DoubleChest) holder;
-			Location loc = ChestManagement.getLocation((Chest) doubleChest.getLeftSide());
-			Team claimedBy = getClaimingTeam(loc);
-			if (claimedBy != null) {
-				return loc;
-			}
+		Location location1 = block.getLocation();
+		Location location2 = ChestManagement.getOtherSide(block);
 
-			loc = ChestManagement.getLocation((Chest) doubleChest.getRightSide());
-			claimedBy = getClaimingTeam(ChestManagement.getLocation((Chest) doubleChest.getRightSide()));
-			if (claimedBy != null) {
-				return loc;
-			}
+		if (ChestManagement.isSingleChest(location1, location2)) {
+			Team claimedBy = getClaimingTeam(location1);
+			if (claimedBy != null) return location1;
+			return null;
 		} else {
-			// single chest
-			Team claimedBy = getClaimingTeam(block.getLocation());
-			if (claimedBy != null) {
-				return block.getLocation();
-			}
-		}
+			Team claimedBy = getClaimingTeam(location1);
+			if (claimedBy != null) return location1;
 
-		return null;
+			claimedBy = getClaimingTeam(location2);
+			if (claimedBy != null) return location2;
+			return null;
+		}
 	}
 
 	/**


### PR DESCRIPTION
I haven't fully tested it, as I think other commands are affected, the hopper event detects the chests just fine. I hope I haven't missed something when rewriting the TeamManager module.

EDIT: forgot the spark links
In the first two tests I put ingots in a chest, copied it with NBTs and filled a Shulker, then repeated a couple of times
Before: https://spark.lucko.me/d26dJrbWom

**After**
Purpur: https://spark.lucko.me/TOe22g9VkT
Spigot: https://spark.lucko.me/VUI1Xp7jEP (Spigot was absolutely dying, the 0.08mspt are caused by the server overloading)
Spigot (removed the heavy items): https://spark.lucko.me/0hGguS542m (this is the actual value)