### PR TITLE
Remove shadow color tag resolver from PermissiveFormatter for compatibility with Paper servers below 1.21.4

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/text/Formatter.java
+++ b/src/main/java/com/booksaw/betterTeams/text/Formatter.java
@@ -110,7 +110,6 @@ public abstract class Formatter {
 				.put("betterteams.chat.format.reset", StandardTags.reset())
 				.put("betterteams.chat.format.legacyreset", LegacyTextTags.RESET)
 				.put("betterteams.chat.format.gradient", StandardTags.gradient())
-				.put("betterteams.chat.format.shadowcolor", StandardTags.shadowColor())
 				.put("betterteams.chat.format.hover", StandardTags.hoverEvent())
 				.put("betterteams.chat.format.click", StandardTags.clickEvent())
 				.put("betterteams.chat.format.insertion", StandardTags.insertion())


### PR DESCRIPTION
Including the shadow color tag resolver in the PermissiveFormatter class causes it to fail to initialize correctly if the server is Paper and is below version 1.21.4 (my best guess). I did not foresee this and should be removed unless an nms trick is implemented.