### PR TITLE
chore: bumping versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,17 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <name>Maven Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>spigot-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
@@ -76,19 +87,19 @@
         <dependency>
             <groupId>com.github.decentsoftware-eu</groupId>
             <artifactId>decentholograms</artifactId>
-            <version>2.8.17</version>
+            <version>2.9.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.2.8</version>
+            <version>7.3.14</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>
             <artifactId>worldguard-bukkit</artifactId>
-            <version>7.0.5</version>
+            <version>7.0.14</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -120,14 +131,14 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.21.0</version>
+            <version>4.23.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.kyori/adventure-text-serializer-legacy -->
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>4.21.0</version>
+            <version>4.23.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.kyori/adventure-text-serializer-bungeecord -->
@@ -141,7 +152,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.3.4</version>
+            <version>4.4.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
@@ -155,13 +166,13 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.12.2</version>
+            <version>5.13.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.12.2</version>
+            <version>5.13.3</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Because junit needs to be bumped together...

The added maven repository is necessary for a transient dependency from decentholograms.
Without it, it will fail to build because of the cache.

I think somewhere along the line they (cryptomin.XSeries) changed from common/old-bukkit/new-bukkit structure to just 1 jar file and uploaded this to maven central. And it's in the cache of github actions.
So adding maven central as the first repository forces the build to look there first and update its cache.