### PR TITLE
Prevent yml data corruption

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/team/storage/storageManager/YamlStorageManager.java
+++ b/src/main/java/com/booksaw/betterTeams/team/storage/storageManager/YamlStorageManager.java
@@ -8,6 +8,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.logging.Level;
 
@@ -31,11 +33,29 @@ public abstract class YamlStorageManager extends TeamManager {
 	}
 
 	public void saveTeamsFile() {
+		File backF = new File("plugins/BetterTeams/" + TEAMLISTSTORAGELOC + ".yml.bak");
+		File preF = new File("plugins/BetterTeams/" + TEAMLISTSTORAGELOC + ".yml.pre");
 		File f = new File("plugins/BetterTeams/" + TEAMLISTSTORAGELOC + ".yml");
+
 		try {
-			teamStorage.save(f);
+			Files.copy(f.toPath(), backF.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		} catch (IOException ex) {
+			Main.plugin.getLogger().log(Level.SEVERE, "Could not save backup to " + backF, ex);
+			return;
+		}
+
+		try {
+			teamStorage.save(preF);
 		} catch (IOException ex) {
 			Main.plugin.getLogger().log(Level.SEVERE, "Could not save config to " + f, ex);
+			return;
+		}
+
+		try {
+			Files.move(preF.toPath(), f.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		} catch (IOException ex) {
+			Main.plugin.getLogger().log(Level.SEVERE, "Could not move " + preF + " to " + f, ex);
+			return;
 		}
 	}
 


### PR DESCRIPTION
This is not intended to be merged in its current state. I am only opening this PR draft in order to share this solution with anyone who may want/need it.

What this edit does:
- Changes the behavior of the plugin when saving teams.yml (data file) in order to avoid data loss if your storage device runs out of space (or other filesystem issue). In this order:
  - Copy the existing `teams.yml` file to `teams.yml.bak`
  - First create a new file: `teams.yml.pre` and write the new data
  - Rename `teams.yml.pre` to `teams.yml` overwriting the existing `teams.yml` file with the new data

If during any step, a write is prevented, the list of tasks is aborted and does not proceed. In this scenario, any new data is discarded but the integrity of the file is preserved, preventing a total loss of data. If the file writing process is interrupted in a weird way (during shutdown / force-kill / etc) the .bak is still present and would allow the admins to simply restore this version.

Realistically, a production ready version of this would probably omit the .bak file and preserve the rest.
