### PR TITLE
initial LuckPerms context support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,14 @@
             <version>3.27.3</version>
             <scope>test</scope>
         </dependency>
+
+<!--    https://repo.maven.apache.org/maven2/net/luckperms/api/-->
+        <dependency>
+            <groupId>net.luckperms</groupId>
+            <artifactId>api</artifactId>
+            <version>5.4</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/booksaw/betterTeams/Main.java
+++ b/src/main/java/com/booksaw/betterTeams/Main.java
@@ -169,6 +169,7 @@ public class Main extends JavaPlugin {
 				luckPermsManager.register();
 			} catch (Exception e) {
 				getLogger().warning("Could not properly hook into LuckPerms, context integration will not be available.");
+				luckPermsManager = null;
 				e.printStackTrace();
 			}
 		}

--- a/src/main/java/com/booksaw/betterTeams/Main.java
+++ b/src/main/java/com/booksaw/betterTeams/Main.java
@@ -20,6 +20,7 @@ import com.booksaw.betterTeams.cooldown.CooldownManager;
 import com.booksaw.betterTeams.cost.CostManager;
 import com.booksaw.betterTeams.events.*;
 import com.booksaw.betterTeams.events.MCTeamManagement.BelowNameType;
+import com.booksaw.betterTeams.integrations.LuckPermsManager;
 import com.booksaw.betterTeams.integrations.UltimateClaimsManager;
 import com.booksaw.betterTeams.integrations.WorldGuardManagerV7;
 import com.booksaw.betterTeams.integrations.ZKothManager;
@@ -36,6 +37,8 @@ import com.booksaw.betterTeams.util.WebhookHandler;
 import com.tcoded.folialib.FoliaLib;
 import lombok.Getter;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.permission.Permission;
 import org.bstats.bukkit.Metrics;
@@ -76,6 +79,8 @@ public class Main extends JavaPlugin {
 
 	@Getter
 	private TeamPlaceholders teamPlaceholders;
+
+	private LuckPermsManager luckPermsManager;
 
 	/**
 	 * FoliaLib instance for Folia/Paper/Spigot support
@@ -156,6 +161,18 @@ public class Main extends JavaPlugin {
 			teamPlaceholders.register();
 		}
 
+		if (Bukkit.getPluginManager().isPluginEnabled("LuckPerms")) {
+			try {
+				LuckPerms luckPerms = LuckPermsProvider.get();
+				getLogger().info("LuckPerms detected! Registering custom context provider.");
+				luckPermsManager = new LuckPermsManager(luckPerms);
+				luckPermsManager.register();
+			} catch (Exception e) {
+				getLogger().warning("Could not properly hook into LuckPerms, context integration will not be available.");
+				e.printStackTrace();
+			}
+		}
+
 		if (Bukkit.getPluginManager().getPlugin("UltimateClaims") != null
 				&& Objects.requireNonNull(Bukkit.getPluginManager().getPlugin("UltimateClaims")).isEnabled()) {
 			if (getConfig().getBoolean("ultimateClaims.enabled")) {
@@ -190,6 +207,10 @@ public class Main extends JavaPlugin {
 
 		if (useHolograms) {
 			HologramManager.holoManager.disable();
+		}
+
+		if (luckPermsManager != null) {
+			luckPermsManager.unregister();
 		}
 
 		if (teamManagement != null) {

--- a/src/main/java/com/booksaw/betterTeams/integrations/LuckPermsManager.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/LuckPermsManager.java
@@ -1,0 +1,98 @@
+package com.booksaw.betterTeams.integrations;
+
+import com.booksaw.betterTeams.PlayerRank;
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.integrations.placeholder.TeamPlaceholderOptionsEnum;
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class LuckPermsManager implements ContextCalculator<Player> {
+
+	private final LuckPerms luckPerms;
+
+	public LuckPermsManager(LuckPerms luckPerms) {
+		this.luckPerms = luckPerms;
+	}
+
+	@Override
+	public void calculate(@NotNull Player player, @NotNull ContextConsumer consumer) {
+		Team team = Team.getTeam(player);
+
+		consumer.accept("bt_inteam", String.valueOf(team != null));
+		if (team == null) {
+			return;
+		}
+		TeamPlayer teamPlayer = team.getTeamPlayer(player);
+
+		// Player specific
+		addContext(consumer, "bt_rank", TeamPlaceholderOptionsEnum.RANK.applyPlaceholderProvider(team, teamPlayer), true);
+		addContext(consumer, "bt_teamchat", TeamPlaceholderOptionsEnum.TEAMCHAT.applyPlaceholderProvider(team, teamPlayer));
+
+		// Team info
+		addContext(consumer, "bt_level", TeamPlaceholderOptionsEnum.LEVEL.applyPlaceholderProvider(team, teamPlayer));
+		addContext(consumer, "bt_open", TeamPlaceholderOptionsEnum.OPEN.applyPlaceholderProvider(team, teamPlayer));
+		addContext(consumer, "bt_pvp", TeamPlaceholderOptionsEnum.PVP.applyPlaceholderProvider(team, teamPlayer));
+		addContext(consumer, "bt_hashome",  String.valueOf(team.getTeamHome() != null));
+
+		// Leaderboard positions
+		addContext(consumer, "bt_positionscore", TeamPlaceholderOptionsEnum.POSITIONSCORE.applyPlaceholderProvider(team, teamPlayer));
+		addContext(consumer, "bt_positionbal", TeamPlaceholderOptionsEnum.POSITIONBAL.applyPlaceholderProvider(team, teamPlayer));
+		addContext(consumer, "bt_positionmembers", TeamPlaceholderOptionsEnum.POSITIONMEMBERS.applyPlaceholderProvider(team, teamPlayer));
+	}
+
+	/**
+	 * Helper method to avoid passing null values to the context consumer.
+	 */
+	private void addContext(ContextConsumer consumer, String key, String value) {
+		addContext(consumer, key, value, false);
+	}
+
+	/**
+	 * Helper method with optional lowercasing.
+	 */
+	private void addContext(ContextConsumer consumer, String key, String value, boolean toLowerCase) {
+		if (value != null) {
+			consumer.accept(key, toLowerCase ? value.toLowerCase() : value);
+		}
+	}
+
+	@Override
+	public @NotNull ContextSet estimatePotentialContexts() {
+		ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
+		builder.add("bt_inteam", "true");
+		builder.add("bt_inteam", "false");
+		builder.add("bt_pvp", "true");
+		builder.add("bt_pvp", "false");
+		builder.add("bt_open", "true");
+		builder.add("bt_open", "false");
+		builder.add("bt_level", "1");
+		builder.add("bt_level", "2");
+
+		for (int i = 1; i <= 3; i++) {
+			builder.add("bt_positionscore", String.valueOf(i));
+			builder.add("bt_positionbal", String.valueOf(i));
+			builder.add("bt_positionmembers", String.valueOf(i));
+		}
+
+		for (PlayerRank rank : PlayerRank.values()) {
+			builder.add("bt_rank", rank.name().toLowerCase());
+		}
+		return builder.build();
+	}
+
+
+
+	public void register() {
+		this.luckPerms.getContextManager().registerCalculator(this);
+	}
+
+	public void unregister() {
+		this.luckPerms.getContextManager().unregisterCalculator(this);
+	}
+}

--- a/src/main/java/com/booksaw/betterTeams/integrations/LuckPermsManager.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/LuckPermsManager.java
@@ -1,9 +1,9 @@
 package com.booksaw.betterTeams.integrations;
 
-import com.booksaw.betterTeams.PlayerRank;
 import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.TeamPlayer;
 import com.booksaw.betterTeams.integrations.placeholder.TeamPlaceholderOptionsEnum;
+import com.booksaw.betterTeams.message.MessageManager;
 import net.luckperms.api.LuckPerms;
 import net.luckperms.api.context.ContextCalculator;
 import net.luckperms.api.context.ContextConsumer;
@@ -31,7 +31,7 @@ public class LuckPermsManager implements ContextCalculator<Player> {
 		TeamPlayer teamPlayer = team.getTeamPlayer(player);
 
 		// Player specific
-		addContext(consumer, "bt_rank", TeamPlaceholderOptionsEnum.RANK.applyPlaceholderProvider(team, teamPlayer), true);
+		addContext(consumer, "bt_rank", TeamPlaceholderOptionsEnum.RANK.applyPlaceholderProvider(team, teamPlayer));
 		addContext(consumer, "bt_teamchat", TeamPlaceholderOptionsEnum.TEAMCHAT.applyPlaceholderProvider(team, teamPlayer));
 
 		// Team info
@@ -50,44 +50,43 @@ public class LuckPermsManager implements ContextCalculator<Player> {
 	 * Helper method to avoid passing null values to the context consumer.
 	 */
 	private void addContext(ContextConsumer consumer, String key, String value) {
-		addContext(consumer, key, value, false);
+		if (value != null) {
+			consumer.accept(key, value);
+		}
 	}
 
-	/**
-	 * Helper method with optional lowercasing.
-	 */
-	private void addContext(ContextConsumer consumer, String key, String value, boolean toLowerCase) {
-		if (value != null) {
-			consumer.accept(key, toLowerCase ? value.toLowerCase() : value);
-		}
+	private void addTrueFalse(ImmutableContextSet.Builder builder, String key) {
+		builder.add(key, "true");
+		builder.add(key, "false");
 	}
 
 	@Override
 	public @NotNull ContextSet estimatePotentialContexts() {
 		ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
-		builder.add("bt_inteam", "true");
-		builder.add("bt_inteam", "false");
-		builder.add("bt_pvp", "true");
-		builder.add("bt_pvp", "false");
-		builder.add("bt_open", "true");
-		builder.add("bt_open", "false");
+		addTrueFalse(builder, "bt_inteam");
+		addTrueFalse(builder, "bt_pvp");
+		addTrueFalse(builder, "bt_open");
+		addTrueFalse(builder, "bt_hashome");
+		
+		builder.add("bt_teamchat", MessageManager.getMessage("placeholder.teamChat"));
+		builder.add("bt_teamchat", MessageManager.getMessage("placeholder.allyChat"));
+		builder.add("bt_teamchat", MessageManager.getMessage("placeholder.globalChat"));
+
+		builder.add("bt_rank", MessageManager.getMessage("placeholder.owner"));
+		builder.add("bt_rank", MessageManager.getMessage("placeholder.admin"));
+		builder.add("bt_rank", MessageManager.getMessage("placeholder.default"));
+
 		builder.add("bt_level", "1");
 		builder.add("bt_level", "2");
-
 		for (int i = 1; i <= 3; i++) {
 			builder.add("bt_positionscore", String.valueOf(i));
 			builder.add("bt_positionbal", String.valueOf(i));
 			builder.add("bt_positionmembers", String.valueOf(i));
 		}
 
-		for (PlayerRank rank : PlayerRank.values()) {
-			builder.add("bt_rank", rank.name().toLowerCase());
-		}
 		return builder.build();
 	}
-
-
-
+	
 	public void register() {
 		this.luckPerms.getContextManager().registerCalculator(this);
 	}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,6 +15,7 @@ softdepend:
   - UltimateClaims
   - DecentHolograms
   - zKoth
+  - LuckPerms
 
 permissions:
   betterTeams.standard:

--- a/wiki/docs/05-dependencies/Dependencies.md
+++ b/wiki/docs/05-dependencies/Dependencies.md
@@ -52,6 +52,10 @@ Turrets do not attack allies
 
 This plugin supports many placeholders which can be used through placeholder API. For more information view the [placeholderAPI page of the wiki](./PlaceholderAPI)
 
+### [LuckPerms](https://luckperms.net/)
+
+BetterTeams can hook into the LuckPerms permission plugin to provide dynamic contexts. For more information view the [LuckPerms page of the wiki](./LuckPerms).
+
 ### [PrimaxTeamGlow](https://www.spigotmc.org/resources/primaxteamglow.127974/)
 
 Highlight your fellow teammates with the glowing effect!

--- a/wiki/docs/05-dependencies/LuckPerms.md
+++ b/wiki/docs/05-dependencies/LuckPerms.md
@@ -16,18 +16,18 @@ For example, you could create a permission that only applies if a player is the 
 
 BetterTeams provides the following contexts (all keys start with `bt_`):
 
-| Context Key                   | Description                                                                 | Example Value(s)                         |
-|-------------------------------|-----------------------------------------------------------------------------|------------------------------------------|
-| `bt_inteam`                   | Checks if a player is in any team.                                          | `true`, `false`                          |
-| `bt_rank`                     | The player's rank within their team.                                        | `owner`, `admin`, `default`              |
-| `bt_teamchat`                 | Current chat mode the player is using.                                      | `Team Chat`, `Ally Chat`, `Global Chat`  |
-| `bt_level`                    | The current level of the player's team.                                     | `5`                                      |
-| `bt_pvp`                      | Checks if the team has friendly-fire enabled.                               | `true`, `false`                          |
-| `bt_open`                     | Checks if the team is open for anyone to join.                              | `true`, `false`                          |
-| `bt_hashome`                  | Checks if the team has set a home.                                          | `true`, `false`                          |
-| `bt_positionscore`            | The team's rank on the score leaderboard.                                   | `1`, `2`, `3`, …                         |
-| `bt_positionbal`              | The team's rank on the balance leaderboard.                                 | `1`, `2`, `3`, …                         |
-| `bt_positionmembers`          | The team's rank on the member-count leaderboard.                            | `1`, `2`, `3`, …                         |
+| Context Key                   | Description                                                                 | Example Value(s)                       |
+|-------------------------------|-----------------------------------------------------------------------------|----------------------------------------|
+| `bt_inteam`                   | Checks if a player is in any team.                                          | `true`, `false`                        |
+| `bt_rank`                     | The player's rank within their team.                                        | From Language file (e.g., `owner`)     |
+| `bt_teamchat`                 | Current chat mode the player is using.                                      | From Language file (e.g., `Team Chat`) |
+| `bt_level`                    | The current level of the player's team.                                     | `1`, `2`, `3`, ...                     |
+| `bt_pvp`                      | Checks if the team has friendly-fire enabled.                               | `true`, `false`                        |
+| `bt_open`                     | Checks if the team is open for anyone to join.                              | `true`, `false`                        |
+| `bt_hashome`                  | Checks if the team has set a home.                                          | `true`, `false`                        |
+| `bt_positionscore`            | The team's rank on the score leaderboard.                                   | `1`, `2`, `3`, …                       |
+| `bt_positionbal`              | The team's rank on the balance leaderboard.                                 | `1`, `2`, `3`, …                       |
+| `bt_positionmembers`          | The team's rank on the member-count leaderboard.                            | `1`, `2`, `3`, …                       |
 
 ---
 
@@ -41,10 +41,9 @@ To give the `kits.member` permission only if the player is in any team:
 /lp group default permission set kits.member true bt_inteam=true
 ```
 :::note
-The values for the `bt_teamchat` context are determined by the return values of chat placeholders in your `messages.yml` file. By default, these are:
-- `placeholder.teamChat`: 'Team Chat'
-- `placeholder.globalChat`: 'Global Chat'
-- `placeholder.allyChat`: 'Ally Chat'
+Some context values are configurable in your language files. The values are sourced from the following placeholder keys:
+- **`bt_rank`**: `placeholder.owner`, `placeholder.admin`, `placeholder.default`
+- **`bt_teamchat`**: `placeholder.teamChat`, `placeholder.allyChat`, `placeholder.globalChat`
 
-If you customize these placeholder values, the `bt_teamchat` context will use your new values.
+If you customize these placeholder values, the contexts will use your new values.
 :::

--- a/wiki/docs/05-dependencies/LuckPerms.md
+++ b/wiki/docs/05-dependencies/LuckPerms.md
@@ -19,12 +19,12 @@ BetterTeams provides the following contexts (all keys start with `bt_`):
 | Context Key                   | Description                                                                 | Example Value(s)                       |
 |-------------------------------|-----------------------------------------------------------------------------|----------------------------------------|
 | `bt_inteam`                   | Checks if a player is in any team.                                          | `true`, `false`                        |
-| `bt_rank`                     | The player's rank within their team.                                        | From Language file (e.g., `owner`)     |
-| `bt_teamchat`                 | Current chat mode the player is using.                                      | From Language file (e.g., `Team Chat`) |
-| `bt_level`                    | The current level of the player's team.                                     | `1`, `2`, `3`, ...                     |
 | `bt_pvp`                      | Checks if the team has friendly-fire enabled.                               | `true`, `false`                        |
 | `bt_open`                     | Checks if the team is open for anyone to join.                              | `true`, `false`                        |
 | `bt_hashome`                  | Checks if the team has set a home.                                          | `true`, `false`                        |
+| `bt_rank`                     | The player's rank within their team.                                        | From Language file (e.g., `owner`)     |
+| `bt_teamchat`                 | Current chat mode the player is using.                                      | From Language file (e.g., `Team Chat`) |
+| `bt_level`                    | The current level of the player's team.                                     | `1`, `2`, `3`, ...                     |
 | `bt_positionscore`            | The team's rank on the score leaderboard.                                   | `1`, `2`, `3`, …                       |
 | `bt_positionbal`              | The team's rank on the balance leaderboard.                                 | `1`, `2`, `3`, …                       |
 | `bt_positionmembers`          | The team's rank on the member-count leaderboard.                            | `1`, `2`, `3`, …                       |

--- a/wiki/docs/05-dependencies/LuckPerms.md
+++ b/wiki/docs/05-dependencies/LuckPerms.md
@@ -1,0 +1,50 @@
+# LuckPerms Integration
+
+BetterTeams can hook into the [LuckPerms](https://luckperms.net/) permission plugin to provide dynamic **contexts**.  
+This is an extremely powerful feature that allows you to grant permissions to players based on their live team data.
+
+---
+
+## What are Contexts?
+
+Contexts are extra conditions that must be met for a permission to apply.  
+For example, you could create a permission that only applies if a player is the `owner` of their team, or if their team's `level` is 5.
+
+---
+
+## Available Contexts
+
+BetterTeams provides the following contexts (all keys start with `bt_`):
+
+| Context Key                   | Description                                                                 | Example Value(s)                         |
+|-------------------------------|-----------------------------------------------------------------------------|------------------------------------------|
+| `bt_inteam`                   | Checks if a player is in any team.                                          | `true`, `false`                          |
+| `bt_rank`                     | The player's rank within their team.                                        | `owner`, `admin`, `default`              |
+| `bt_teamchat`                 | Current chat mode the player is using.                                      | `Team Chat`, `Ally Chat`, `Global Chat`  |
+| `bt_level`                    | The current level of the player's team.                                     | `5`                                      |
+| `bt_pvp`                      | Checks if the team has friendly-fire enabled.                               | `true`, `false`                          |
+| `bt_open`                     | Checks if the team is open for anyone to join.                              | `true`, `false`                          |
+| `bt_hashome`                  | Checks if the team has set a home.                                          | `true`, `false`                          |
+| `bt_positionscore`            | The team's rank on the score leaderboard.                                   | `1`, `2`, `3`, …                         |
+| `bt_positionbal`              | The team's rank on the balance leaderboard.                                 | `1`, `2`, `3`, …                         |
+| `bt_positionmembers`          | The team's rank on the member-count leaderboard.                            | `1`, `2`, `3`, …                         |
+
+---
+
+## Usage Examples
+
+### Team Membership Permission
+
+To give the `kits.member` permission only if the player is in any team:
+
+```bash
+/lp group default permission set kits.member true bt_inteam=true
+```
+:::note
+The values for the `bt_teamchat` context are determined by the return values of chat placeholders in your `messages.yml` file. By default, these are:
+- `placeholder.teamChat`: 'Team Chat'
+- `placeholder.globalChat`: 'Global Chat'
+- `placeholder.allyChat`: 'Ally Chat'
+
+If you customize these placeholder values, the `bt_teamchat` context will use your new values.
+:::


### PR DESCRIPTION
contexts:

| Context Key                   | Description                                                                 | Example Value(s)                         |
|-------------------------------|-----------------------------------------------------------------------------|------------------------------------------|
| `bt_inteam`                   | Checks if a player is in any team.                                          | `true`, `false`                          |
| `bt_rank`                     | The player's rank within their team.                                        | `owner`, `admin`, `default`              |
| `bt_teamchat`                 | Current chat mode the player is using.                                      | `Team Chat`, `Ally Chat`, `Global Chat`  |
| `bt_level`                    | The current level of the player's team.                                     | `5`                                      |
| `bt_pvp`                      | Checks if the team has friendly-fire enabled.                               | `true`, `false`                          |
| `bt_open`                     | Checks if the team is open for anyone to join.                              | `true`, `false`                          |
| `bt_hashome`                  | Checks if the team has set a home.                                          | `true`, `false`                          |
| `bt_positionscore`            | The team's rank on the score leaderboard.                                   | `1`, `2`, `3`, …                         |
| `bt_positionbal`              | The team's rank on the balance leaderboard.                                 | `1`, `2`, `3`, …                         |
| `bt_positionmembers`          | The team's rank on the member-count leaderboard.                            | `1`, `2`, `3`, …                         |

- add luckperms.md in wiki 

check ommand:
`/lp user <player> info`
