### PR TITLE
Feat: Implement Placeholder for meta system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,21 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.20.0</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.20.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- AssertJ -->
         <dependency>
             <groupId>org.assertj</groupId>

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/IndividualTeamWithDataPlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/IndividualTeamWithDataPlaceholderProvider.java
@@ -1,0 +1,11 @@
+package com.booksaw.betterTeams.integrations.placeholder;
+
+import com.booksaw.betterTeams.Team;
+
+/**
+ * Interface for placeholders that require additional data
+ */
+public interface IndividualTeamWithDataPlaceholderProvider {
+
+	String getPlaceholderForTeam(Team team, String data);
+}

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderOptionsEnum.java
@@ -20,10 +20,12 @@ public enum TeamPlaceholderOptionsEnum {
 	MAXMONEY(new MaxMoneyPlaceholderProvider()), MAXMEMBERS(new MaxMembersPlaceholderProvider()), MAXWARPS(new MaxWarpsPlaceholderProvider()),
 	PVP(new PvpPlaceholderProvider()),
 	HASHOME(new HasHomePlaceholderProvider()),
-	TEAMCHAT(new TeamChatPlaceholderProvider());
+	TEAMCHAT(new TeamChatPlaceholderProvider()),
+	META(new MetaPlaceholderProvider());
 
 	private final IndividualTeamPlaceholderProvider teamProvider;
 	private final IndividualTeamPlayerPlaceholderProvider teamPlayerProvider;
+	private final IndividualTeamWithDataPlaceholderProvider teamWithDataProvider;
 
 	/**
 	 * Constructor to take in an interface per enum value
@@ -31,6 +33,7 @@ public enum TeamPlaceholderOptionsEnum {
 	TeamPlaceholderOptionsEnum(IndividualTeamPlaceholderProvider teamProvider) {
 		this.teamProvider = teamProvider;
 		this.teamPlayerProvider = null;
+		this.teamWithDataProvider = null;
 	}
 
 	/**
@@ -39,6 +42,13 @@ public enum TeamPlaceholderOptionsEnum {
 	TeamPlaceholderOptionsEnum(IndividualTeamPlayerPlaceholderProvider teamPlayerProvider) {
 		this.teamPlayerProvider = teamPlayerProvider;
 		this.teamProvider = null;
+		this.teamWithDataProvider = null;
+	}
+
+	TeamPlaceholderOptionsEnum(IndividualTeamWithDataPlaceholderProvider teamWithDataProvider) {
+		this.teamWithDataProvider = teamWithDataProvider;
+		this.teamProvider = null;
+		this.teamPlayerProvider = null;
 	}
 
 	public String applyPlaceholderProvider(Team team, TeamPlayer player) {
@@ -52,11 +62,23 @@ public enum TeamPlaceholderOptionsEnum {
 		return null;
 	}
 
+	public String applyPlaceholderProvider(Team team, TeamPlayer player, String data) {
+		if (teamWithDataProvider != null) {
+			return teamWithDataProvider.getPlaceholderForTeam(team, data);
+		}
+		// fallback
+		return applyPlaceholderProvider(team, player);
+	}
+
 	public static TeamPlaceholderOptionsEnum getEnumValue(String str) {
 		try {
 			return TeamPlaceholderOptionsEnum.valueOf(str.toUpperCase());
 		} catch (IllegalArgumentException e) {
 			return null;
 		}
+	}
+
+	public boolean requiresData() {
+		return teamWithDataProvider != null;
 	}
 }

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderService.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholderService.java
@@ -24,4 +24,18 @@ public final class TeamPlaceholderService {
 
 	}
 
+	public static String getPlaceholder(String placeholder, Team team, TeamPlayer player, String data) {
+		TeamPlaceholderOptionsEnum enumValue = TeamPlaceholderOptionsEnum.getEnumValue(placeholder);
+		if (enumValue == null) {
+			return null;
+		}
+		return enumValue.applyPlaceholderProvider(team, player, data);
+	}
+
+
+	public static boolean requiresData(String placeholder) {
+		TeamPlaceholderOptionsEnum enumValue = TeamPlaceholderOptionsEnum.getEnumValue(placeholder);
+		return enumValue != null && enumValue.requiresData();
+	}
+
 }

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholders.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholders.java
@@ -91,8 +91,7 @@ public class TeamPlaceholders extends PlaceholderExpansion {
 		}
 
 		// Case 2: dynamic placeholders that require data (like %betterteams_meta_key%)
-		TeamPlaceholderOptionsEnum option = TeamPlaceholderOptionsEnum.getEnumValue(split[0]);
-		if (option != null && option.requiresData()) {
+		if (TeamPlaceholderService.requiresData(split[0])) {
 			if (player == null) {
 				return null;
 			}
@@ -102,8 +101,7 @@ public class TeamPlaceholders extends PlaceholderExpansion {
 			}
 			TeamPlayer tp = team.getTeamPlayer(player);
 			String data = originalIdentifier.substring(originalIdentifier.indexOf('_') + 1);
-
-			return option.applyPlaceholderProvider(team, tp, data);
+			return TeamPlaceholderService.getPlaceholder(split[0], team, tp, data);
 		}
 
 		// Case 3: static or leaderboard placeholders (cacheable)
@@ -210,9 +208,5 @@ public class TeamPlaceholders extends PlaceholderExpansion {
 
 	private enum SortType {
 		SCORE, BALANCE, MEMBERS
-	}
-
-	private String getMetaValue(Team team, String key) {
-		return team.getMeta().get().get(key).orElse(MessageManager.getMessage("placeholder.noTeam"));
 	}
 }

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholders.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholders.java
@@ -66,46 +66,29 @@ public class TeamPlaceholders extends PlaceholderExpansion {
 		identifier = identifier.toLowerCase();
 		String[] split = identifier.split("_");
 
-		// Case 1: simple placeholders like %betterteams_name%
-		if (split.length == 1) {
-			if (player == null) {
-				return null;
-			}
+		String cachedValue = placeholderCache.get(identifier);
+		if (cachedValue != null) return cachedValue;
 
-			if ("inteam".equalsIgnoreCase(split[0])) {
-				return Team.getTeamManager().isInTeam(player)
-						? MessageManager.getMessage("placeholder.inteam")
-						: MessageManager.getMessage("placeholder.notinteam");
-			}
+		if (player == null) return null;
 
-			Team team = Team.getTeam(player);
-			if (team == null) {
-				return MessageManager.getMessage("placeholder.noTeam");
-			}
-
-			TeamPlayer tp = team.getTeamPlayer(player);
-			if (tp == null) {
-				return MessageManager.getMessage("placeholder.noTeam");
-			}
-			return TeamPlaceholderService.getPlaceholder(identifier, team, tp);
+		if ("inteam".equalsIgnoreCase(split[0])) {
+			return Team.getTeamManager().isInTeam(player)
+					? MessageManager.getMessage("placeholder.inteam")
+					: MessageManager.getMessage("placeholder.notinteam");
 		}
 
-		// Case 2: dynamic placeholders that require data (like %betterteams_meta_key%)
-		if (TeamPlaceholderService.requiresData(split[0])) {
-			if (player == null) {
-				return null;
-			}
-			Team team = Team.getTeam(player);
-			if (team == null) {
-				return MessageManager.getMessage("placeholder.noTeam");
-			}
-			TeamPlayer tp = team.getTeamPlayer(player);
+		Team team = Team.getTeam(player);
+		if (team == null) return MessageManager.getMessage("placeholder.noTeam");
+
+		TeamPlayer tp = team.getTeamPlayer(player);
+		if (tp == null) return MessageManager.getMessage("placeholder.noTeam");
+
+		String placeholderType = split[0];
+		if (TeamPlaceholderService.requiresData(placeholderType)) {
 			String data = originalIdentifier.substring(originalIdentifier.indexOf('_') + 1);
-			return TeamPlaceholderService.getPlaceholder(split[0], team, tp, data);
+			return TeamPlaceholderService.getPlaceholder(placeholderType, team, tp, data);
 		}
-
-		// Case 3: static or leaderboard placeholders (cacheable)
-		return placeholderCache.get(identifier);
+		return TeamPlaceholderService.getPlaceholder(identifier, team, tp);
 	}
 
 	private String getStaticPlaceholder(String identifier) {

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholders.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholders.java
@@ -27,7 +27,7 @@ public class TeamPlaceholders extends PlaceholderExpansion {
 		this.plugin = plugin;
 		placeholderCache = new Cache.Builder<String, String>()
 				.maximumSize(300)
-				.expireAfterWrite(Duration.ofSeconds(plugin.getConfig().getInt("invalidateCacheSeconds")))
+				.expireAfterWrite(Duration.ofSeconds(plugin.getConfig().getInt("invalidateCacheSeconds", 60)))
 				.build(this::getStaticPlaceholder);
 	}
 
@@ -104,7 +104,7 @@ public class TeamPlaceholders extends PlaceholderExpansion {
 				return processRankedTeamDataPlaceholder(identifier, SortType.MEMBERS);
 			case "static":
 				return processStaticTeamPlaceholder(split);
-			case "staticplayer_":
+			case "staticplayer":
 				return processStaticTeamPlayerPlaceholder(split);
 			default:
 				return null;

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/MetaPlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/provider/MetaPlaceholderProvider.java
@@ -1,0 +1,12 @@
+package com.booksaw.betterTeams.integrations.placeholder.provider;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.integrations.placeholder.IndividualTeamWithDataPlaceholderProvider;
+import com.booksaw.betterTeams.message.MessageManager;
+
+public class MetaPlaceholderProvider implements IndividualTeamWithDataPlaceholderProvider {
+	@Override
+	public String getPlaceholderForTeam(Team team, String data) {
+		return team.getMeta().get().get(data).orElse(MessageManager.getMessage("placeholder.noMeta"));
+	}
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -18,6 +18,7 @@ cooldown.wait: '&4You need to wait another {0} seconds before running that!'
 cost.tooPoor: '&4You are too poor to run that command'
 cost.run: '&4&l-{0}'
 placeholder.noTeam: ''
+placeholder.noMeta: ''
 placeholder.noDescription: ''
 placeholder.money: '{0}'
 placeholder.owner: Owner

--- a/src/test/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholdersTest.java
+++ b/src/test/java/com/booksaw/betterTeams/integrations/placeholder/TeamPlaceholdersTest.java
@@ -1,0 +1,300 @@
+package com.booksaw.betterTeams.integrations.placeholder;
+
+import com.booksaw.betterTeams.Team;
+import com.booksaw.betterTeams.TeamPlayer;
+import com.booksaw.betterTeams.Utils;
+import com.booksaw.betterTeams.message.MessageManager;
+import com.booksaw.betterTeams.team.TeamManager;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@DisplayName("TeamPlaceholders Test")
+@SuppressWarnings("SpellCheckingInspection")
+@ExtendWith(MockitoExtension.class)
+class TeamPlaceholdersTest {
+
+	private TeamPlaceholders teamPlaceholders;
+
+	@Mock
+	private Plugin mockPlugin;
+	@Mock
+	private FileConfiguration mockConfig;
+	@Mock
+	private Player mockPlayer;
+	@Mock
+	private OfflinePlayer mockOfflinePlayer;
+
+	@Mock
+	private Team mockTeam;
+	@Mock
+	private TeamPlayer mockTeamPlayer;
+	@Mock
+	private TeamManager mockTeamManager;
+
+	private MockedStatic<Team> teamStatic;
+	private MockedStatic<MessageManager> messageManagerStatic;
+	private MockedStatic<Utils> utilsStatic;
+	private MockedStatic<TeamPlaceholderService> placeholderServiceStatic;
+
+	@BeforeEach
+	@SuppressWarnings("ResultOfMethodCallIgnored")
+	void setUp() {
+		when(mockPlugin.getConfig()).thenReturn(mockConfig);
+//		when(mockConfig.getInt("invalidateCacheSeconds", 60)).thenReturn(30);
+
+		teamStatic = mockStatic(Team.class);
+		messageManagerStatic = mockStatic(MessageManager.class);
+		utilsStatic = mockStatic(Utils.class);
+		placeholderServiceStatic = mockStatic(TeamPlaceholderService.class);
+
+		teamStatic.when(Team::getTeamManager).thenReturn(mockTeamManager);
+		messageManagerStatic.when(() -> MessageManager.getMessage(anyString()))
+				.thenAnswer(invocation -> "msg:" + invocation.getArgument(0));
+
+		teamPlaceholders = new TeamPlaceholders(mockPlugin);
+	}
+
+	@AfterEach
+	void tearDown() {
+		teamStatic.close();
+		messageManagerStatic.close();
+		utilsStatic.close();
+		placeholderServiceStatic.close();
+	}
+
+	@Nested
+	@DisplayName("onPlaceholderRequest() Player-Specific Tests")
+	class OnPlaceholderRequestTests {
+
+		@Test
+		@DisplayName("Should return null if player is null")
+		void testRequestWithNullPlayer() {
+			assertNull(teamPlaceholders.onPlaceholderRequest(null, "any_identifier"));
+		}
+
+		@Test
+		@DisplayName("Should return 'not in team' message for %betterteams_inTeam% when player is not in a team")
+		void testPlayerNotInTeamForInTeamPlaceholder() {
+			when(mockTeamManager.isInTeam(mockPlayer)).thenReturn(false);
+			String result = teamPlaceholders.onPlaceholderRequest(mockPlayer, "inTeam");
+			assertEquals("msg:placeholder.notinteam", result);
+		}
+
+		@Test
+		@DisplayName("Should return 'in team' message for %betterteams_inTeam% when player is in a team")
+		void testPlayerInTeamForInTeamPlaceholder() {
+			when(mockTeamManager.isInTeam(mockPlayer)).thenReturn(true);
+			String result = teamPlaceholders.onPlaceholderRequest(mockPlayer, "inTeam");
+			assertEquals("msg:placeholder.inteam", result);
+		}
+
+		@Test
+		@DisplayName("Should return 'no team' message if player is not in a team for a team-specific placeholder")
+		void testPlayerNotInTeamForTeamSpecificPlaceholder() {
+			teamStatic.when(() -> Team.getTeam(mockPlayer)).thenReturn(null);
+			String result = teamPlaceholders.onPlaceholderRequest(mockPlayer, "name");
+			assertEquals("msg:placeholder.noTeam", result);
+		}
+
+		@Test
+		@DisplayName("Should handle a standard placeholder request correctly")
+		void testStandardPlaceholderRequest() {
+			teamStatic.when(() -> Team.getTeam(mockPlayer)).thenReturn(mockTeam);
+			when(mockTeam.getTeamPlayer(mockPlayer)).thenReturn(mockTeamPlayer);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("name", mockTeam, mockTeamPlayer))
+					.thenReturn("TeamAlpha");
+
+			String result = teamPlaceholders.onPlaceholderRequest(mockPlayer, "name");
+
+			assertEquals("TeamAlpha", result);
+			placeholderServiceStatic.verify(() -> TeamPlaceholderService.getPlaceholder("name", mockTeam, mockTeamPlayer));
+		}
+
+		@Test
+		@DisplayName("Should handle a placeholder with data correctly")
+		void testDataPlaceholderRequest() {
+			String identifier = "meta_SomeKey";
+
+			teamStatic.when(() -> Team.getTeam(mockPlayer)).thenReturn(mockTeam);
+			when(mockTeam.getTeamPlayer(mockPlayer)).thenReturn(mockTeamPlayer);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.requiresData("meta")).thenReturn(true);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("meta", mockTeam, mockTeamPlayer, "SomeKey"))
+					.thenReturn("SomeValue");
+
+			String result = teamPlaceholders.onPlaceholderRequest(mockPlayer, identifier);
+
+			assertEquals("SomeValue", result);
+			placeholderServiceStatic.verify(() -> TeamPlaceholderService.getPlaceholder("meta", mockTeam, mockTeamPlayer, "SomeKey"));
+		}
+	}
+
+	@Nested
+	@DisplayName("Static and Ranked Placeholder Tests")
+	class StaticAndRankedPlaceholderTests {
+
+		@Test
+		@DisplayName("Should resolve a ranked placeholder by score")
+		void testRankedPlaceholder_Score() {
+			String[] sortedTeams = {"TeamBravo", "TeamAlpha"};
+			when(mockTeamManager.sortTeamsByScore()).thenReturn(sortedTeams);
+			teamStatic.when(() -> Team.getTeam("TeamAlpha")).thenReturn(mockTeam);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("name", mockTeam, null))
+					.thenReturn("TeamAlpha");
+
+			String result = teamPlaceholders.onPlaceholderRequest(null, "position_name_2");
+			assertEquals("TeamAlpha", result);
+			verify(mockTeamManager).sortTeamsByScore();
+		}
+
+		@Test
+		@DisplayName("Should resolve a ranked placeholder by balance")
+		void testRankedPlaceholder_Balance() {
+			String[] sortedTeams = {"TeamBravo", "TeamAlpha"};
+			when(mockTeamManager.sortTeamsByBalance()).thenReturn(sortedTeams);
+			teamStatic.when(() -> Team.getTeam("TeamBravo")).thenReturn(mockTeam);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("name", mockTeam, null))
+					.thenReturn("TeamBravo");
+
+			String result = teamPlaceholders.onPlaceholderRequest(null, "balanceposition_name_1");
+			assertEquals("TeamBravo", result);
+			verify(mockTeamManager).sortTeamsByBalance();
+		}
+
+		@Test
+		@DisplayName("Should return null for a ranked placeholder with an invalid rank")
+		void testRankedPlaceholder_InvalidRank() {
+			assertNull(teamPlaceholders.onPlaceholderRequest(null, "position_name_abc"));
+			assertNull(teamPlaceholders.onPlaceholderRequest(null, "position_name_0"));
+		}
+
+		@Test
+		@DisplayName("Should return 'no team' message for a ranked placeholder with rank out of bounds")
+		void testRankedPlaceholder_RankOutOfBounds() {
+			String[] sortedTeams = {"TeamAlpha"};
+			when(mockTeamManager.sortTeamsByScore()).thenReturn(sortedTeams);
+			String result = teamPlaceholders.onPlaceholderRequest(null, "position_name_2");
+			assertEquals("msg:placeholder.noTeam", result);
+		}
+
+		@Test
+		@DisplayName("Should resolve a static team placeholder successfully")
+		void testStaticTeamPlaceholder_Success() {
+			teamStatic.when(() -> Team.getTeam("myteam")).thenReturn(mockTeam);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("score", mockTeam, null))
+					.thenReturn("100");
+
+			String result = teamPlaceholders.onPlaceholderRequest(null, "static_score_MyTeam");
+			assertEquals("100", result);
+		}
+
+		@Test
+		@DisplayName("Should return 'no team' message if static team placeholder team is not found")
+		void testStaticTeamPlaceholder_TeamNotFound() {
+			teamStatic.when(() -> Team.getTeam("noteam")).thenReturn(null);
+
+			String result = teamPlaceholders.onPlaceholderRequest(null, "static_score_NoTeam");
+			assertEquals("msg:placeholder.noTeam", result);
+		}
+
+		@Test
+		@DisplayName("Should resolve a static player placeholder successfully")
+		void testStaticPlayerPlaceholder_Success() {
+			String playerName = "testplayer";
+			utilsStatic.when(() -> Utils.getOfflinePlayer(playerName)).thenReturn(mockOfflinePlayer);
+			teamStatic.when(() -> Team.getTeam(mockOfflinePlayer)).thenReturn(mockTeam);
+			when(mockTeam.getTeamPlayer(mockOfflinePlayer)).thenReturn(mockTeamPlayer);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("rank", mockTeam, mockTeamPlayer))
+					.thenReturn("Admin");
+
+			String result = teamPlaceholders.onPlaceholderRequest(null, "staticplayer_rank_TestPlayer");
+
+			assertEquals("Admin", result);
+			verify(mockTeam).getTeamPlayer(mockOfflinePlayer);
+		}
+
+		@Test
+		@DisplayName("Should return 'no team' message if static player placeholder player is not found")
+		void testStaticPlayerPlaceholder_PlayerNotFound() {
+			utilsStatic.when(() -> Utils.getOfflinePlayer("noplayer")).thenReturn(null);
+
+			String result = teamPlaceholders.onPlaceholderRequest(null, "staticplayer_title_NoPlayer");
+			assertEquals("msg:placeholder.noTeam", result);
+		}
+	}
+
+	@Nested
+	@DisplayName("Cache Logic Tests")
+	class CacheTests {
+
+		@Test
+		@DisplayName("Should cache the result of a static placeholder request")
+		void testStaticPlaceholderIsCached() {
+			// --- First Request ---
+			teamStatic.when(() -> Team.getTeam("myteam")).thenReturn(mockTeam);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("score", mockTeam, null))
+					.thenReturn("100");
+
+			String result1 = teamPlaceholders.onPlaceholderRequest(null, "static_score_MyTeam");
+			assertEquals("100", result1);
+
+			// Verify the underlying service was called
+			placeholderServiceStatic.verify(() -> TeamPlaceholderService.getPlaceholder("score", mockTeam, null), times(1));
+
+			// --- Second Request ---
+			String result2 = teamPlaceholders.onPlaceholderRequest(null, "static_score_MyTeam");
+			assertEquals("100", result2);
+
+			// Verify the service was NOT called again, proving the cache was hit
+			placeholderServiceStatic.verifyNoMoreInteractions();
+		}
+
+		@Test
+		@DisplayName("invalidateCache() should clear the cache")
+		void testInvalidateCache() {
+			teamStatic.when(() -> Team.getTeam("myteam")).thenReturn(mockTeam);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("score", mockTeam, null))
+					.thenReturn("100");
+
+			// First request to populate the cache
+			teamPlaceholders.onPlaceholderRequest(null, "static_score_MyTeam");
+			placeholderServiceStatic.verify(() -> TeamPlaceholderService.getPlaceholder("score", mockTeam, null), times(1));
+
+			// Invalidate the cache
+			teamPlaceholders.invalidateCache();
+
+			// Second request should trigger the service call again
+			teamPlaceholders.onPlaceholderRequest(null, "static_score_MyTeam");
+			placeholderServiceStatic.verify(() -> TeamPlaceholderService.getPlaceholder("score", mockTeam, null), times(2));
+		}
+
+		@Test
+		@DisplayName("Should not cache player-specific placeholder requests")
+		void testPlayerSpecificPlaceholderIsNotCached() {
+			teamStatic.when(() -> Team.getTeam(mockPlayer)).thenReturn(mockTeam);
+			when(mockTeam.getTeamPlayer(mockPlayer)).thenReturn(mockTeamPlayer);
+			placeholderServiceStatic.when(() -> TeamPlaceholderService.getPlaceholder("name", mockTeam, mockTeamPlayer))
+					.thenReturn("TeamAlpha");
+
+			// First call
+			teamPlaceholders.onPlaceholderRequest(mockPlayer, "name");
+			placeholderServiceStatic.verify(() -> TeamPlaceholderService.getPlaceholder("name", mockTeam, mockTeamPlayer), times(1));
+
+			// Second call
+			teamPlaceholders.onPlaceholderRequest(mockPlayer, "name");
+			// The service should be called again, proving it was not cached
+			placeholderServiceStatic.verify(() -> TeamPlaceholderService.getPlaceholder("name", mockTeam, mockTeamPlayer), times(2));
+		}
+	}
+}

--- a/wiki/docs/05-dependencies/PlaceholderAPI.md
+++ b/wiki/docs/05-dependencies/PlaceholderAPI.md
@@ -74,6 +74,7 @@ you want to use in place of the `{rank}` variable. The options are as follows:
 * `hasHome` - Returns the value of `placeholder.hasHome` if the targeted team has a home, otherwise the value
   of `placeholder.noHome`
 * `teamChat` - Returns the configurable message matching if the player is in team chat, ally chat or global chat
+* `meta_<key>` - returns the meta of team or value of `placeholder.noMeta` (Only works in the context of `%betterteams_meta_<key>%`)
 
 ## Example Placeholders
 


### PR DESCRIPTION
This pull request introduces a more flexible placeholder system that can handle placeholders requiring additional data. The primary use case for this is to allow server administrators to create placeholders for custom team metadata (e.g., `%betterteams_meta_city%`).

### **Changes Implemented**

* **New Interface:** Added the `IndividualTeamWithDataPlaceholderProvider` interface to create a contract for placeholders that require an additional data string (such as a metadata key).
* **New Provider:** Created `MetaPlaceholderProvider` as the first implementation of the new interface, allowing direct access to team meta fields.
* **Placeholder Logic Update:** The core `onPlaceholderRequest` method in `TeamPlaceholders` has been updated to differentiate between simple placeholders and data-driven ones, routing requests to the appropriate provider.
* **Service Layer Update:** Added a `requiresData()` method to `TeamPlaceholderService` to facilitate the new routing logic.

### **Testing**

* A comprehensive JUnit 5 test suite has been created for the `TeamPlaceholders` class to ensure all logic is working as expected.
* The tests cover all paths: player-specific, static, ranked, caching, and the new data-driven placeholders.
* *(Note: The initial test structure was generated by AI and has been thoroughly reviewed, corrected, and verified by a human for accuracy and completeness.)*

### **Dependency Changes**

* Added `mockito-core` and `mockito-junit-jupiter` to the `pom.xml` under the `test` scope to support the new unit tests.
---
**pull request text writed by ai XD(my english is bad**
