### PR TITLE
HomeAnchorManagement fixes

### DIFF
--- a/src/main/java/com/booksaw/betterTeams/Main.java
+++ b/src/main/java/com/booksaw/betterTeams/Main.java
@@ -105,6 +105,8 @@ public class Main extends JavaPlugin {
 	FileConfiguration teams;
 	private DamageManagement damageManagement;
 
+	private HomeAnchorManagement homeAnchorManagement;
+
 	private ConfigManager configManager;
 
 	private BukkitAudiences adventure;
@@ -221,6 +223,10 @@ public class Main extends JavaPlugin {
 			teamManagement.removeAll(false);
 		}
 
+		if (homeAnchorManagement != null) {
+			homeAnchorManagement.unregisterEvent();
+		}
+
 		Team.disable();
 
 		MessageManager.dumpMessages();
@@ -325,6 +331,7 @@ public class Main extends JavaPlugin {
 		closeAdventure = false;
 		onDisable();
 		teamManagement = null;
+		homeAnchorManagement = null;
 		reloadConfig();
 		configManager = new ConfigManager("config", true);
 
@@ -467,8 +474,8 @@ public class Main extends JavaPlugin {
 		getServer().getPluginManager().registerEvents(new InventoryManagement(), this);
 		getServer().getPluginManager().registerEvents(new RankupEvents(), this);
 		if (getConfig().getBoolean("anchor.enable")) {
-			HomeAnchorManagement homeAnchorListener = new HomeAnchorManagement(this);
-			homeAnchorListener.registerEvent();
+			homeAnchorManagement = new HomeAnchorManagement(this);
+			homeAnchorManagement.registerEvent();
 		}
 	}
 

--- a/src/main/java/com/booksaw/betterTeams/TeamPlayer.java
+++ b/src/main/java/com/booksaw/betterTeams/TeamPlayer.java
@@ -7,7 +7,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -63,21 +65,19 @@ public class TeamPlayer {
 	 * @param player the player that is associated with this object
 	 * @param rank   the rank that the player has
 	 */
-	public TeamPlayer(@NotNull OfflinePlayer player, @NotNull PlayerRank rank) {
+	public TeamPlayer(@NotNull OfflinePlayer player, @Nullable PlayerRank rank) {
+		Objects.requireNonNull(player, "player cannot be null");
 		this.playerUUID = player.getUniqueId();
-		this.rank = rank;
+		this.rank = rank != null ? rank : PlayerRank.DEFAULT;
 	}
 
-	public TeamPlayer(OfflinePlayer player, PlayerRank rank, String title) {
-		this.playerUUID = player.getUniqueId();
-		this.rank = rank;
-		this.title = title;
+	public TeamPlayer(@NotNull OfflinePlayer player, @Nullable PlayerRank rank, @Nullable String title) {
+		this(player, rank);
+		this.title = title != null ? title : "";
 	}
 
-	public TeamPlayer(OfflinePlayer player, PlayerRank rank, String title, boolean anchor) {
-		this.playerUUID = player.getUniqueId();
-		this.rank = rank;
-		this.title = title;
+	public TeamPlayer(@NotNull OfflinePlayer player, @Nullable PlayerRank rank, @Nullable String title, boolean anchor) {
+		this(player, rank, title);
 		this.anchor = anchor;
 	}
 

--- a/src/main/java/com/booksaw/betterTeams/events/HomeAnchorManagement.java
+++ b/src/main/java/com/booksaw/betterTeams/events/HomeAnchorManagement.java
@@ -17,23 +17,20 @@ import com.booksaw.betterTeams.customEvents.PlayerHomeAnchorEvent;
 
 public class HomeAnchorManagement implements Listener {
 
-    private final JavaPlugin plugin;
-    private final EventPriority defaultPriority = EventPriority.NORMAL;
-    private final EventPriority priority;
-    private final EnumSet<EventPriority> allowedPriorities = EnumSet.of(
-            EventPriority.HIGH,
-            EventPriority.HIGHEST,
-            EventPriority.NORMAL,
-            EventPriority.LOW,
-            EventPriority.LOWEST);
+	private static final EventPriority defaultPriority = EventPriority.NORMAL;
 
-    private final boolean checkUsePermission;
-    private final boolean checkAnchoredPlayer;
+	private static final EnumSet<EventPriority> allowedPriorities = EnumSet.of(
+			EventPriority.HIGH,
+			EventPriority.HIGHEST,
+			EventPriority.NORMAL,
+			EventPriority.LOW,
+			EventPriority.LOWEST);
+
+    private final JavaPlugin plugin;
+    private final EventPriority priority;
 
     public HomeAnchorManagement(Main plugin) {
         this.plugin = plugin;
-        this.checkUsePermission = plugin.getConfig().getBoolean("anchor.checkUsePermission");
-        this.checkAnchoredPlayer = plugin.getConfig().getBoolean("anchor.checkAnchoredPlayer");
         this.priority = getConfiguredPriority();
     }
 
@@ -58,10 +55,16 @@ public class HomeAnchorManagement implements Listener {
                 plugin);
     }
 
+	public void unregisterEvent() {
+		PlayerRespawnEvent.getHandlerList().unregister(this);
+	}
+
     public void onRespawn(@NotNull PlayerRespawnEvent e) {
-		if (e.isAnchorSpawn() && plugin.getConfig().getBoolean("ignoreObsidianAnchorRespawn", false))
+
+		if (e.isAnchorSpawn() && plugin.getConfig().getBoolean("anchor.ignoreObsidianAnchorRespawn", false))
 			return;
-		if (e.isBedSpawn() && plugin.getConfig().getBoolean("ignoreBedRespawn", false))
+
+		if (e.isBedSpawn() && plugin.getConfig().getBoolean("anchor.ignoreBedRespawn", false))
 			return;
 
         Team team = Team.getTeam(e.getPlayer());
@@ -69,10 +72,13 @@ public class HomeAnchorManagement implements Listener {
 
         TeamPlayer teamPlayer = team.getTeamPlayer(e.getPlayer());
 		if (teamPlayer == null) return;
-        if (checkAnchoredPlayer && !teamPlayer.isAnchored()) return;
+
+        if (plugin.getConfig().getBoolean("anchor.checkAnchoredPlayer")
+				&& !teamPlayer.isAnchored()) return;
 
         // This goes before the team home for ensuring it exists even after this
-        if (checkUsePermission && !e.getPlayer().hasPermission("betterteams.anchor.use")) return;
+        if (plugin.getConfig().getBoolean("anchor.checkUsePermission")
+				&& !e.getPlayer().hasPermission("betterteams.anchor.use")) return;
 
         Location teamHome = team.getTeamHome();
         if (teamHome == null) return;

--- a/src/main/java/com/booksaw/betterTeams/team/MemberSetComponent.java
+++ b/src/main/java/com/booksaw/betterTeams/team/MemberSetComponent.java
@@ -33,7 +33,7 @@ public class MemberSetComponent extends TeamPlayerSetComponent {
 		Player onlinePlayer = offlinePlayer.getPlayer();
 
 		// if the player is offline there will be no player object for them
-		if (onlinePlayer != null) {
+		if (offlinePlayer.isOnline() && onlinePlayer != null) {
 			for (TeamPlayer player : set) {
 				if (player.getPlayer().isOnline()) {
 					MessageManager.sendMessage(player.getPlayer().getPlayer(), "join.notify", onlinePlayer.getDisplayName());
@@ -48,7 +48,9 @@ public class MemberSetComponent extends TeamPlayerSetComponent {
 		Team.getTeamManager().playerJoinTeam(team, teamPlayer);
 		set.add(teamPlayer);
 
-		if (onlinePlayer != null && onlinePlayer.hasPermission("betterteams.anchor.allowonjoin")) team.setPlayerAnchor(teamPlayer, true);
+		if (offlinePlayer.isOnline() && onlinePlayer != null
+				&& onlinePlayer.hasPermission("betterteams.anchor.allowonjoin"))
+			team.setPlayerAnchor(teamPlayer, true);
 
 		Bukkit.getPluginManager().callEvent(new PostPlayerJoinTeamEvent(team, teamPlayer));
 	}

--- a/src/main/java/com/booksaw/betterTeams/team/MemberSetComponent.java
+++ b/src/main/java/com/booksaw/betterTeams/team/MemberSetComponent.java
@@ -12,6 +12,7 @@ import com.booksaw.betterTeams.message.MessageManager;
 import com.booksaw.betterTeams.team.storage.team.TeamStorage;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 
 public class MemberSetComponent extends TeamPlayerSetComponent {
 
@@ -25,25 +26,29 @@ public class MemberSetComponent extends TeamPlayerSetComponent {
 			throw new CancelledEventException(event);
 		}
 
-		OfflinePlayer p = teamPlayer.getPlayer();
+		OfflinePlayer offlinePlayer = teamPlayer.getPlayer();
 
-		team.getInvitedPlayers().remove(p.getUniqueId());
+		team.getInvitedPlayers().remove(offlinePlayer.getUniqueId());
+
+		Player onlinePlayer = offlinePlayer.getPlayer();
 
 		// if the player is offline there will be no player object for them
-		if (p.isOnline()) {
+		if (onlinePlayer != null) {
 			for (TeamPlayer player : set) {
 				if (player.getPlayer().isOnline()) {
-					MessageManager.sendMessage(player.getPlayer().getPlayer(), "join.notify", p.getPlayer().getDisplayName());
+					MessageManager.sendMessage(player.getPlayer().getPlayer(), "join.notify", onlinePlayer.getDisplayName());
 				}
 			}
 
 			if (Main.plugin.teamManagement != null) {
-				Main.plugin.teamManagement.displayBelowName(p.getPlayer());
+				Main.plugin.teamManagement.displayBelowName(onlinePlayer);
 			}
 		}
 
 		Team.getTeamManager().playerJoinTeam(team, teamPlayer);
 		set.add(teamPlayer);
+
+		if (onlinePlayer != null && onlinePlayer.hasPermission("betterteams.anchor.allowonjoin")) team.setPlayerAnchor(teamPlayer, true);
 
 		Bukkit.getPluginManager().callEvent(new PostPlayerJoinTeamEvent(team, teamPlayer));
 	}


### PR DESCRIPTION
Make "anchor.ignoreObsidianAnchorRespawn" and "anchor.ignoreBedRespawn" actually work. HomeAnchorManagement should now be properly disabled and re-enabled when /teama reload is run.