### PR TITLE
Upgrade to Spigot 1.20 and Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <repositories>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.5-R0.1-SNAPSHOT</version>
+            <version>1.20-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -157,6 +157,7 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
             <version>4.24.0</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.kyori/adventure-text-serializer-legacy -->
@@ -164,6 +165,7 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
             <version>4.23.0</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.kyori/adventure-text-serializer-bungeecord -->
@@ -171,6 +173,7 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-bungeecord</artifactId>
             <version>4.4.1</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/net.kyori/adventure-platform-bukkit -->
@@ -178,13 +181,7 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
             <version>4.4.1</version>
-        </dependency>
-
-        <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>33.4.8-jre</version>
+            <scope>compile</scope>
         </dependency>
 
         <!-- JUnit 5 -->
@@ -251,6 +248,11 @@
                             <!-- !! MAKE SURE TO CHANGE THIS TO YOUR PLUGIN'S GROUP & PLUGIN NAME !! -->
                             <shadedPattern>com.booksaw.betterTeams.lib.folialib</shadedPattern>
                         </relocation>
+                        <!-- Adventure platforms -->
+                        <relocation>
+                            <pattern>net.kyori</pattern>
+                            <shadedPattern>com.booksaw.betterTeams.lib.net.kyori</shadedPattern>
+                        </relocation>
                     </relocations>
                     <filters>
                         <filter>
@@ -276,8 +278,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>17</source>
+                    <target>17</target>
                     <compilerArgs>
                         <arg>-Xlint:deprecation</arg>
                         <arg>-Xlint:unchecked</arg>
@@ -297,7 +299,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.11.2</version>
                 <configuration>
-                    <reportOutputDirectory>docs/javadocs</reportOutputDirectory>
+                    <outputDirectory>docs/javadocs</outputDirectory>
                     <sourcepath>src/main/java</sourcepath>
                 </configuration>
             </plugin>

--- a/src/main/java/com/booksaw/betterTeams/integrations/placeholder/IndividualTeamPlaceholderProvider.java
+++ b/src/main/java/com/booksaw/betterTeams/integrations/placeholder/IndividualTeamPlaceholderProvider.java
@@ -2,9 +2,9 @@ package com.booksaw.betterTeams.integrations.placeholder;
 
 import com.booksaw.betterTeams.Team;
 import com.booksaw.betterTeams.team.TeamManager;
-import org.apache.commons.lang.ArrayUtils;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -18,11 +18,17 @@ public interface IndividualTeamPlaceholderProvider {
 	default String getPlaceholderForTeam(@NotNull Team team, @NotNull Function<TeamManager, String[]> sortingFunction) {
 		// Get the sorted teams using the provided sorting function
 		String[] sortedTeams = sortingFunction.apply(Team.getTeamManager());
+		int position = 0;
 
-		// Find the position of the team in the sorted array
-		int position = ArrayUtils.indexOf(sortedTeams, team.getName()) + 1;
+		if (sortedTeams != null) {
+			for (int i = 0; i < sortedTeams.length; i++) {
+				if (Objects.equals(sortedTeams[i], team.getName())) {
+					position = i + 1;
+					break;
+				}
+			}
+		}
 
-		// Return the position as a string
-		return position + "";
+		return String.valueOf(position);
 	}
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ description: A plugin to create teams with other players
 main: com.booksaw.betterTeams.Main
 website: https://www.spigotmc.org/resources/better-teams.17129/
 folia-supported: true
-api-version: 1.13
+api-version: 1.20
 
 softdepend:
   - PlaceholderAPI


### PR DESCRIPTION
Should fix #886
There are currently 20 servers on 1.16.5 and 58 on 'other' in bStats, which is less than 2.1% of the total server count.
I think it's time to move on and drop support for older versions and still support 98% of the servers using this plugin.
https://jitpack.io/com/github/RVSkeLe/BetterTeams/feat~java17-074dc39c0a-1/build.log

This also fixes some issues with dependencies, especially Adventure, which wasn't properly relocated, also removed Guava since it wasn't used and reduced the file size back to 2MB instead of 5MB