### PR TITLE
Jitpack Build Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <java.version>17</java.version>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <java.version>21</java.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Since child pom has java 21 where parent has java 17 it conflict and hence jitpack failed to build. In this I just match both pareent and child pom to Java version 21 to fix Jitpack build error.