### PR TITLE
Changes in the LunarClient integration

### DIFF
--- a/BetterTeams/src/main/java/com/booksaw/betterTeams/integrations/apollo/ApolloManager.java
+++ b/BetterTeams/src/main/java/com/booksaw/betterTeams/integrations/apollo/ApolloManager.java
@@ -138,11 +138,20 @@ public class ApolloManager implements Listener {
 
 	private JsonObject createTeamMemberObject(Player member, Team team) {
 		JsonObject obj = new JsonObject();
+
+		Color awtColor = team.getColor().asBungee().getColor();
+		if (awtColor == null) awtColor = Color.WHITE;
+
+		int rgb = awtColor.getRGB();
+
 		obj.add("player_uuid", createUuidObject(member.getUniqueId()));
+
 		obj.addProperty("adventure_json_player_name", toJson(
-			Component.text(member.getName()).color(TextColor.color(team.getColor().asBungee().getColor().getRGB()))
+				Component.text(member.getName()).color(TextColor.color(rgb))
 		));
-		obj.add("marker_color", createColorObject(team.getColor().asBungee().getColor()));
+
+		obj.add("marker_color", createColorObject(awtColor));
+
 		obj.add("location", createLocationObject(member.getLocation()));
 		return obj;
 	}

--- a/BetterTeams/src/main/java/com/booksaw/betterTeams/integrations/apollo/ApolloManager.java
+++ b/BetterTeams/src/main/java/com/booksaw/betterTeams/integrations/apollo/ApolloManager.java
@@ -52,7 +52,7 @@ public class ApolloManager implements Listener {
 
 		Bukkit.getPluginManager().registerEvents(this, Main.plugin);
 
-		Main.plugin.getFoliaLib().getScheduler().runTimerAsync(this::refreshAllTeams, 1L, 1L);
+		Main.plugin.getFoliaLib().getScheduler().runTimerAsync(this::refreshAllTeams, 1L, 20L);
 		Main.plugin.getLogger().info("Registered Apollo Teamview integration");
 	}
 

--- a/BetterTeams/src/main/java/com/booksaw/betterTeams/integrations/apollo/ApolloManager.java
+++ b/BetterTeams/src/main/java/com/booksaw/betterTeams/integrations/apollo/ApolloManager.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Integrates BetterTeams with the Apollo (Lunar Client) Team View module
@@ -41,7 +42,7 @@ public class ApolloManager implements Listener {
 	private static final String LUNAR_CHANNEL = "lunar:apollo";
 
 	/** UUIDs of online players confirmed to be running Lunar Client with Apollo. */
-	private static final Set<UUID> apolloPlayers = new HashSet<>();
+	private static final Set<UUID> apolloPlayers = ConcurrentHashMap.newKeySet();
 
 	public ApolloManager() {
 		var messenger = Bukkit.getServer().getMessenger();

--- a/BetterTeams/src/main/resources/config.yml
+++ b/BetterTeams/src/main/resources/config.yml
@@ -623,14 +623,14 @@ ultimateClaims:
   # All members of a team are trusted in the claim
   enabled: true
 
-# INTEGRATION WITH LUNAR CLIENT (APOLLO)
+# INTEGRATION WITH LUNARCLIENT (APOLLO)
 # Enables the Apollo Team View module for players using Lunar Client.
 # Teammates will have markers displayed above their heads, on the minimap, and in the direction HUD.
 # No additional plugin is required - this uses the lightweight plugin messaging API.
 apollo:
   teamview:
-    # Set to false to disable the Apollo Teamview integration entirely
-    enabled: true
+    # Set to true to enable the Apollo Teamview integration
+    enabled: false
 
 # INTEGRATION WITH WORLDGUARD
 # Plugin link: https://dev.bukkit.org/projects/worldguard


### PR DESCRIPTION
The feedback from server owners about the feature was negative overall. The program was also throwing a lot of NPEs, causing confusion.
This PR should resolve the NPEs, improve thread safety, lower the refresh rate, and disable the integration by default.